### PR TITLE
Added missing description of backup EntryProcessor null issue, as discussed in issue #6162

### DIFF
--- a/src/EntryProcessor.md
+++ b/src/EntryProcessor.md
@@ -97,3 +97,4 @@ public interface EntryBackupProcessor<K, V> extends Serializable {
 
 ![image](images/NoteSmall.jpg) ***NOTE***: *EntryProcessors run via Operation Threads that are dedicated to specific partitions.  Therefore with long running EntryProcessor executions other partition operations cannot be processed, such as a 'map.put(key)'.  With this is in mind it is good practice to make your EntryProcessor executions as quick as possible*
 
+![image](images/NoteSmall.jpg) ***NOTE***: *There is a possibility that an `EntryProcessor` can see that a key exists but its backup processor may not find it at run time due to an unsent backup of a previous operation (e.g. a previous put). In those situations, Hazelcast internally/eventually will sync those owner and backup partitions so you will not lose any data. When coding an `EntryBackupProcessor`, you should take that case into account, otherwise `NullPointerException` can be seen since `Map.Entry.getValue()` may return `null`.*

--- a/src/EntryProcessorAbstract.md
+++ b/src/EntryProcessorAbstract.md
@@ -41,3 +41,4 @@ public abstract class AbstractEntryProcessor <K, V>
 
 In the above example, the method `getBackupProcessor` returns an `EntryBackupProcessor` instance. This means the same processing will be applied to both the primary and backup entries. If you want to apply the processing only upon the primary entries, then make the `getBackupProcessor` method return null. 
 
+![image](images/NoteSmall.jpg) ***NOTE***: *Beware of the null issue described at the end of the [EntryProcessor Overview](#entry-processor-overview) section of this documentation. Due to an yet unsent backup from a previous operation, an `EntryBackupProcessor` may temporarily receive `null` from `Map.Entry.getValue()` even though the value actually exists in the map. If you decide to use `AbstractEntryProcessor`, make sure your code logic is not sensitive to null values, or you may encounter `NullPointerException` during runtime.*


### PR DESCRIPTION
- Added missing description of backup EntryProcessor null issue, as discussed in https://github.com/hazelcast/hazelcast/issues/6162
- EntryProcessor.md: mostly copied the already existing information from the EntryBackupProcessor class javadoc
- EntryProcessorAbstract.md: added a note at the end. I wasn't sure how to correctly link to the Note section, so I attempted to link to the EntryProcessor Overview section. Please verify if the link works.