### PR TITLE
Fixed usage of private API in MonitoringWithJMX

### DIFF
--- a/src/Management/MonitoringWithJMX.md
+++ b/src/Management/MonitoringWithJMX.md
@@ -23,7 +23,7 @@ Then enable the Hazelcast property `hazelcast.jmx` (please refer to the [System 
 
 - By programmatic configuration:
    
-`config.setProperty(GroupProperty.ENABLE_JMX, "true");`
+`config.setProperty("hazelcast.jmx", "true");`
    
 - By Spring XML configuration:
    


### PR DESCRIPTION
We should not use private API in the reference manual.

It would be nice if this could be fixed in the public release as soon as possible.