### PR TITLE
Fixed single quotes in code which broke PDF generation

### DIFF
--- a/src/ClusterSHScript.md
+++ b/src/ClusterSHScript.md
@@ -29,7 +29,7 @@ The script `cluster.sh` is self-documented; you can see the parameter descriptio
 #### Example Usages for cluster.sh
 
 Let's say you have a cluster running on remote machines and one Hazelcast member is running on the IP  `172.16.254.1` and on the port
-`5702`. The group name and password of the cluster are `test' and `test`.
+`5702`. The group name and password of the cluster are `test` and `test`.
 
 <br></br>
 **Getting the cluster state:**

--- a/src/ManagementCenter.md
+++ b/src/ManagementCenter.md
@@ -643,7 +643,7 @@ Once it is **ON**, the status of your cluster will be stored on your disk as lon
 
 You can go back in time using the slider and/or calendar and check your cluster's situation at the selected time. All data structures and members can be monitored as if you are using the management center normally (charts and data tables for each data structure and members). Using the arrow buttons placed at both sides of the slider, you can go back or further with steps of 5 seconds. It will show status if Time Travel has been **ON** at the selected time in past; otherwise, all the charts and tables will be shown as empty.
 
-The historical data collected with Time Travel feature are stored in a file database on the disk. These files can be found in the folder `<User's Home Directory>/mancenter<Hazelcast version>`, e.g. `/home/mancenter3.5`. This folder can be changed using the `hazelcast.mancenter.home` property on the server where Management Center is running.
+The historical data collected with Time Travel feature are stored in a file database on the disk. These files can be found in the folder `<User‘s Home Directory>/mancenter<Hazelcast version>`, e.g. `/home/mancenter3.5`. This folder can be changed using the `hazelcast.mancenter.home` property on the server where Management Center is running.
 
 Time travel data files are created monthly. Their file name format is `[group-name]-[year][month].db` and
  `[group-name]-[year][month].lg`. Time travel data is kept in the `*.db` files. The files with the extension `lg` are temporary files created internally and you do not have to worry about them.

--- a/src/QuerySQL.md
+++ b/src/QuerySQL.md
@@ -14,15 +14,16 @@ Set<Employee> employees = map.values( new SqlPredicate( "active AND age < 30" ) 
 **AND/OR:** `<expression> AND <expression> AND <expression>... `
 
 - `active AND age>30`
-- `active=false OR age = 45 OR name = 'Joe' `
-- `active AND ( age > 20 OR salary < 60000 ) `
+- `active=false OR age = 45 OR name = ‘Joe‘`
+- `active AND ( age > 20 OR salary < 60000 )`
 <br><br>
+
 
 **Equality:** `=, !=, <, <=, >, >=`
 
 - `<expression> = value`
 - `age <= 30`
-- `name = "Joe"`
+- `name = ‘Joe‘`
 - `salary != 50000`
 <br><br>
 
@@ -42,29 +43,27 @@ Set<Employee> employees = map.values( new SqlPredicate( "active AND age < 30" ) 
 - `age IN ( 20, 30, 40 ) AND salary BETWEEN ( 50000, 80000 )`
 <br><br>
 
-**LIKE:** `<attribute> [NOT] LIKE 'expression'`
+
+**LIKE:** `<attribute> [NOT] LIKE "expression"`
 
 The `%` (percentage sign) is placeholder for multiple characters, an `_` (underscore) is placeholder for only one character.
 
-- `name LIKE 'Jo%'` (true for 'Joe', 'Josh', 'Joseph' etc.)
-- `name LIKE 'Jo_'` (true for 'Joe'; false for 'Josh')
-- `name NOT LIKE 'Jo_'` (true for 'Josh'; false for 'Joe')
-- `name LIKE 'J_s%'` (true for 'Josh', 'Joseph'; false 'John', 'Joe')
+- `name LIKE ‘Jo%‘` (true for 'Joe', 'Josh', 'Joseph' etc.)
+- `name LIKE ‘Jo_‘` (true for 'Joe'; false for 'Josh')
+- `name NOT LIKE ‘Jo_‘` (true for 'Josh'; false for 'Joe')
+- `name LIKE ‘J_s%‘` (true for 'Josh', 'Joseph'; false 'John', 'Joe')
 <br><br>
 
 
-
-
-**ILIKE:** `<attribute> [NOT] ILIKE ‘expression’ `
+**ILIKE:** `<attribute> [NOT] ILIKE ‘expression’`
 
 Similar to LIKE predicate but in a case-insensitive manner.
 
-- `name ILIKE 'Jo%'` (true for 'Joe', 'joe', 'jOe','Josh','joSH', etc.)
-- `name ILIKE 'Jo_'` (true for 'Joe' or 'jOE'; false for 'Josh')
+- `name ILIKE ‘Jo%‘` (true for 'Joe', 'joe', 'jOe','Josh','joSH', etc.)
+- `name ILIKE ‘Jo_‘` (true for 'Joe' or 'jOE'; false for 'Josh')
 <br><br>
-
 
 
 **REGEX**: `<attribute> [NOT] REGEX ‘expression’`
  
-- `name REGEX  'abc-.*’` (true for 'abc-123'; false for 'abx-123')
+- `name REGEX ‘abc-.*‘` (true for 'abc-123'; false for 'abx-123')


### PR DESCRIPTION
I got errors like this when building the PDF locally:
```
! LaTeX Error: Command \textquotesingle unavailable in encoding T1.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.9329 ...t{name\ LIKE\ \textquotesingle{}Jo\%‘}

pandoc: Error producing PDF from TeX source
```

Fixed by using a different single quote character, as already done in other places.