### PR TITLE
Skipable PDF creation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,9 @@ function buildDocumentation {
     createMergedMarkdownFile
     createSingleHTML
     createMancenterDocumentation
-    createPDF
+    if [ "$2" != "--skipPDF" ]; then
+        createPDF
+    fi
     delete
     echo "Done"
 }
@@ -212,4 +214,4 @@ function delete {
     $(rm -rf "./src/images")
 }
 
-buildDocumentation $1
+buildDocumentation $@


### PR DESCRIPTION
Made the PDF creation skipable with the parameter "--skipPDF" (needs to be the second argument after the version number. This is useful for developers who want to maintain their documentation and need a fast way to update the final HTML output.

Example usage:
`build.sh 3.6 --skipPDF`