### PR TITLE
Updated map listener with predicate documentation

### DIFF
--- a/src/SystemProperties-Member.md
+++ b/src/SystemProperties-Member.md
@@ -48,6 +48,7 @@ Property Name | Default Value | Type | Description
 `hazelcast.lock.max.lease.time.seconds`|Long.MAX_VALUE | long | All locks which are acquired without an explicit lease time use this value (in seconds) as the lease time. When you want to set an explicit lease time for your locks, you cannot set it to a longer time than this value.
 `hazelcast.logging.type` | jdk | enum |   Name of [logging](#logging-configuration) framework type to send logging events.
 `hazelcast.mancenter.home` | mancenter | string |  Folder where Management Center data files are stored (license information, time travel information, etc.).
+`hazelcast.map.entry.filtering.natural.event.types` | false | bool | Notify [entry listeners with predicates](#listening-to-map-entries-with-predicates) on map entry updates with events that match entry, update or exit from predicate value space.
 `hazelcast.map.expiry.delay.seconds`|10|int|Useful to deal with some possible edge cases. For example, when using EntryProcessor, without this delay, you may see an EntryProcessor running on owner partition found a key but EntryBackupProcessor did not find it on backup. As a result of this, when backup promotes to owner, you will end up an unprocessed key.
 `hazelcast.map.load.chunk.size` | 1000 | int |   Chunk size for [MapLoader](#loading-and-storing-persistent-data)'s map initialization process (MapLoader.loadAllKeys()).
 `hazelcast.map.replica.wait.seconds.for.scheduled.tasks`|10|int|Scheduler delay for map tasks those will be executed on backup members.


### PR DESCRIPTION
Updated documentation on usage of new property `hazelcast.map.entry.filtering.natural.event.types` introduced in version 3.7 that alters listener-with-predicate behavior