### PR TITLE
added small aws explanation

### DIFF
--- a/src/OtherNetworkConfigurations.md
+++ b/src/OtherNetworkConfigurations.md
@@ -211,6 +211,7 @@ The `aws` element includes parameters to allow the members to form a cluster on 
 
 
 ![image](images/NoteSmall.jpg) ***NOTE:*** *If you are using a cloud provider other than AWS, you can use the programmatic configuration to specify a TCP/IP cluster. The members will need to be retrieved from that provider (e.g. JClouds).*
+![image](images/NoteSmall.jpg) ***NOTE:*** *hazelcast-cloud module has been renamed as hazelcast-aws module. If you want to use Aws Discovery, you should add hazelcast-aws jar file to your environment. For more information please look [Hazelcast Aws Readme.](https://github.com/hazelcast/hazelcast-aws/blob/master/README.md)*
 
 #### discovery-strategies element
 


### PR DESCRIPTION
we have renamed hazelcast-cloud as hazelcast-aws. 
this is small explanation for that change. @Serdaro, i am not sure, maybe we should put this explanation to another section.