### PR TITLE
Add hazelcast 3.6.x compatibility switch flag per PR #9066

### DIFF
--- a/src/JavaClientSystemProperties.md
+++ b/src/JavaClientSystemProperties.md
@@ -14,7 +14,7 @@ Property Name | Default Value | Type | Description
 `hazelcast.client.max.concurrent.invocations`|Integer.MAX_VALUE|string|Maximum allowed number of concurrent invocations. You can apply a constraint on the number of concurrent invocations in order to prevent the system from overloading. If the maximum number of concurrent invocations is exceeded and a new invocation comes in, Hazelcast throws `HazelcastOverloadException`.
 `hazelcast.client.invocation.timeout.seconds`|120|string|Time to give up the invocation when a member in the member list is not reachable.
 `hazelcast.client.shuffle.member.list`|true|string|The client shuffles the given member list to prevent all clients to connect to the same member when this property is `false`. When it is set to `true`, the client tries to connect to the members in the given order.
-
+`hazelcast.compatibility.3.6.server`|false|bool|When this property is true, if the client can not know the server version it will assume that the server is version 3.6.x.
 
 ## Sample Codes for Client
 

--- a/src/SystemProperties-Member.md
+++ b/src/SystemProperties-Member.md
@@ -22,6 +22,7 @@ Property Name | Default Value | Type | Description
 `hazelcast.client.invocation.timeout.seconds`|120|string|Time to give up the invocation when a member in the member list is not reachable.
 `hazelcast.client.max.no.heartbeat.seconds`|300|int|Time after which the member assumes the client is dead and closes its connections to the client.
 `hazelcast.client.shuffle.member.list`|true|string|The client shuffles the given member list to prevent all clients to connect to the same member when this property is `false`. When it is set to `true`, the client tries to connect to the members in the given order.
+`hazelcast.compatibility.3.6.client`|false|bool|When this property is true, if the server can not determine the connected client version, it shall assume that it is of 3.6.x version client. This property is especially needed if you are using ICache (or JCache).
 `hazelcast.connect.all.wait.seconds` | 120 | int | Timeout to connect all other cluster members when a member is joining to a cluster.
 `hazelcast.connection.monitor.interval` | 100 | int  |   Minimum interval in milliseconds to consider a connection error as critical.
 `hazelcast.connection.monitor.max.faults` | 3 | int  |   Maximum IO error count before disconnecting from a member.

--- a/src/SystemProperties.md
+++ b/src/SystemProperties.md
@@ -47,6 +47,7 @@ Property Name | Default Value | Type | Description
 `hazelcast.client.invocation.timeout.seconds`|120|string|Time to give up the invocation when a member in the member list is not reachable.
 `hazelcast.client.max.no.heartbeat.seconds`|300|int|Time after which the member assumes the client is dead and closes its connections to the client.
 `hazelcast.client.shuffle.member.list`|true|string|The client shuffles the given member list to prevent all clients to connect to the same member when this property is `false`. When it is set to `true`, the client tries to connect to the members in the given order.
+`hazelcast.compatibility.3.6.client`|false|bool|When this property is true, if the server can not determine the connected client version, it shall assume that it is of 3.6.x version client. This property is especially needed if you are using ICache (or JCache).
 `hazelcast.connect.all.wait.seconds` | 120 | int | Timeout to connect all other cluster members when a member is joining to a cluster.
 `hazelcast.connection.monitor.interval` | 100 | int  |   Minimum interval in milliseconds to consider a connection error as critical.
 `hazelcast.connection.monitor.max.faults` | 3 | int  |   Maximum IO error count before disconnecting from a member.


### PR DESCRIPTION
Added the two new system properties hazelcast.compatibility.3.6.client and hazelcast.compatibility.3.6.server.