### PR TITLE
Backport: Fix broken links for using-wildcards section

### DIFF
--- a/src/ConfiguringHazelcast.md
+++ b/src/ConfiguringHazelcast.md
@@ -45,7 +45,7 @@ For details about all elements and attributes used to configure Hazelcast, pleas
 
 Besides declarative configuration, you can configure your cluster programmatically. Just instantiate a `Config` object and add/remove/modify properties. Please refer to the Programmatic Configuration section in [Configuration Overview](#configuration-overview) for a configuration code example.
 
-You can use wildcards while configuring Hazelcast. Please refer to the [Using Wildcard section](#using-wildcard) for details.
+You can use wildcards while configuring Hazelcast. Please refer to the [Using Wildcards section](#using-wildcards) for details.
 
 Hazelcast also offers system properties to fine tune some aspects of Hazelcast. Please refer to the [System Properties section](#system-properties) for details.
 

--- a/src/HazelcastConfiguration.md
+++ b/src/HazelcastConfiguration.md
@@ -4,6 +4,6 @@
 This chapter describes how Hazelcast can be configured and details the tools which can be used while configuring. It includes the following sections:
 
 - [Configuration Overview](#configuration-overview): Provides the options used to configure Hazelcast.
-- [Using Wildcard](#using-wildcard): Describes the usage of the wildcard character (`*`) while configuring Hazelcast.
+- [Using Wildcards](#using-wildcards): Describes the usage of the wildcard character (`*`) while configuring Hazelcast.
 - [Using Variables](#using-variables): Describes how to use variables in declarative configurations.
 - [Composing Declarative Configuration](#composing-declarative-configuration): Describes how to produce a declarative configuration file out of several configuration files.

--- a/src/Map-Persistence.md
+++ b/src/Map-Persistence.md
@@ -176,7 +176,7 @@ The following are the descriptions of MapStore configuration elements and attrib
 
 #### Storing Entries to Multiple Maps
 
-A configuration can be applied to more than one map using wildcards (see [Using Wildcard](#using-wildcard)), meaning that the configuration is shared among the maps. But `MapStore` does not know which entries to store when there is one configuration applied to multiple maps. 
+A configuration can be applied to more than one map using wildcards (see [Using Wildcards](#using-wildcards)), meaning that the configuration is shared among the maps. But `MapStore` does not know which entries to store when there is one configuration applied to multiple maps.
 
 To store entries when there is one configuration applied to multiple maps, use Hazelcast's `MapStoreFactory` interface. Using the `MapStoreFactory` interface, `MapStore`s for each map can be created when a wildcard configuration is used. Example code is shown below.
 

--- a/src/Map.md
+++ b/src/Map.md
@@ -85,5 +85,5 @@ All `ConcurrentMap` operations such as `put` and `remove` might wait if the key 
 Also see:
 
 - [Data Affinity section](#data-affinity).
-- [Map Configuration with wildcards](#using-wildcard).
+- [Map Configuration with wildcards](#using-wildcards).
 

--- a/src/NativeClientSecurity.md
+++ b/src/NativeClientSecurity.md
@@ -49,7 +49,7 @@ HazelcastInstance client = HazelcastClient.newHazelcastClient( clientConfig );
 
 ### Authorization
 
-Hazelcast client authorization is configured by a client permission policy. Hazelcast has a default permission policy implementation that uses permission configurations defined in the Hazelcast security configuration. Default policy permission checks are done against instance types (map, queue, etc.), instance names (map, queue, name, etc.), instance actions (put, read, remove, add, etc.), client endpoint addresses, and client principal defined by the Credentials object. Instance and principal names and endpoint addresses can be defined as wildcards(*). Please see the [Network Configuration section](#network-configuration) and [Using Wildcard section](#using-wildcard).
+Hazelcast client authorization is configured by a client permission policy. Hazelcast has a default permission policy implementation that uses permission configurations defined in the Hazelcast security configuration. Default policy permission checks are done against instance types (map, queue, etc.), instance names (map, queue, name, etc.), instance actions (put, read, remove, add, etc.), client endpoint addresses, and client principal defined by the Credentials object. Instance and principal names and endpoint addresses can be defined as wildcards(*). Please see the [Network Configuration section](#network-configuration) and [Using Wildcards section](#using-wildcards).
 
 ```xml
 <security enabled="true">


### PR DESCRIPTION
Backport of: https://github.com/hazelcast/hazelcast-reference-manual/pull/199