### PR TITLE
Extend existing quorum support to lock and queue

### DIFF
--- a/documentation.index
+++ b/documentation.index
@@ -50,6 +50,7 @@ src/DDS.md
 		src/Queue-SampleQueueCode.md
 		src/Queue-BoundedQueue.md
 		src/Queue-Persistence.md
+		src/Queue-Quorum.md
 		src/Queue-Configuration.md
 	src/MultiMap.md
 	src/Set.md

--- a/src/Map-Locks.md
+++ b/src/Map-Locks.md
@@ -140,3 +140,33 @@ The ABA problem occurs in environments when a shared resource is open to change 
 To prevent these kind of problems, you can assign a version number and check it before any write to be sure that nothing has changed between consecutive reads. Although all the other fields will be equal, the version field will prevent objects from being seen as equal. This is the optimistic locking strategy, and it is used in environments that do not expect intensive concurrent changes on a specific key.
 
 In Hazelcast, you can apply the [optimistic locking](#optimistic-locking) strategy with the map `replace` method.
+
+### Lock split brain protection with pessimistic locking
+
+Locks can be configured to check the number of currently present members before applying a locking operation. If the check fails, the lock operation will fail with a `QuorumException` (see [Split-Brain Protection](#split-brain-protection)). As pessimistic locking uses lock operations internally, it will also use the configured lock quorum. This means that you can configure a lock quorum with the same name or a pattern that matches the map name. Note that the quorum for IMap locking actions can be different from the quorum for other IMap actions.  
+
+The following actions will then check for lock quorum before being applied  : 
+- `IMap#lock(K)` and `IMap#lock(K, long, java.util.concurrent.TimeUnit)`
+- `IMap#isLocked`
+- `IMap#tryLock(K)`, `IMap#tryLock(K, long, java.util.concurrent.TimeUnit)` and `IMap#tryLock(K, long, java.util.concurrent.TimeUnit, long, java.util.concurrent.TimeUnit)`
+- `IMap#unlock`
+- `IMap#forceUnlock`
+- `MultiMap#lock(K)` and `MultiMap#lock(K, long, java.util.concurrent.TimeUnit)`
+- `MultiMap#isLocked`
+- `MultiMap#tryLock(K)`, `MultiMap#tryLock(K, long, java.util.concurrent.TimeUnit)` and `MultiMap#tryLock(K, long, java.util.concurrent.TimeUnit, long, java.util.concurrent.TimeUnit)`
+- `MultiMap#unlock`
+- `MultiMap#forceUnlock`
+
+
+An example of declarative configuration : 
+```xml
+<map name="myMap">
+  <quorum-ref>map-actions-quorum</quorum-ref>
+</map>
+
+<lock name="myMap">
+    <quorum-ref>map-lock-actions-quorum</quorum-ref>
+</lock>
+```
+
+Here the configured map will use the `map-lock-actions-quorum` quorum for map lock actions and the `map-actions-quorum` quorum for other map actions.

--- a/src/Queue-Configuration.md
+++ b/src/Queue-Configuration.md
@@ -2,7 +2,6 @@
 
 The following are examples of queue configurations. It includes the `QueueStore` configuration, which is explained in the [Queueing with Persistent Datastore](#queueing-with-persistent-datastore) section.
 
-
 **Declarative:**
 
 ```xml
@@ -12,37 +11,39 @@ The following are examples of queue configurations. It includes the `QueueStore`
     <async-backup-count>0</async-backup-count>
     <empty-queue-ttl>-1</empty-queue-ttl>
     <item-listeners>
-       <item-listener>
-          com.hazelcast.examples.ItemListener
-       </item-listener>
-    <item-listeners>
+        <item-listener>com.hazelcast.examples.ItemListener</item-listener>
+    </item-listeners>
+    <queue-store>
+        <class-name>com.hazelcast.QueueStoreImpl</class-name>
+        <properties>
+            <property name="binary">false</property>
+            <property name="memory-limit">10000</property>
+            <property name="bulk-load">500</property>
+        </properties>
+    </queue-store>
+    <quorum-ref>quorumRuleWithThreeNodes</quorum-ref>
 </queue>
-<queue-store>
-    <class-name>com.hazelcast.QueueStoreImpl</class-name>
-    <properties>
-       <property name="binary">false</property>
-       <property name="memory-limit">10000</property>
-       <property name="bulk-load">500</property>
-    </properties>
-</queue-store>   
 ```
 
 **Programmatic:**
 
 ```java
 Config config = new Config();
-QueueConfig queueConfig = config.getQueueConfig();
-queueConfig.setName( "MyQueue" ).setBackupCount( "1" )
-        .setMaxSize( "0" ).setStatisticsEnabled( "true" );
+QueueConfig queueConfig = config.getQueueConfig("default");
+queueConfig.setName("MyQueue")
+           .setBackupCount(1)
+           .setMaxSize(0)
+           .setStatisticsEnabled(true)
+           .setQuorumName("quorum-name");
 queueConfig.getQueueStoreConfig()
-        .setEnabled ( "true" )
-        .setClassName( "com.hazelcast.QueueStoreImpl" )
-        .setProperty( "binary", "false" );
+           .setEnabled(true)
+           .setClassName("com.hazelcast.QueueStoreImpl")
+           .setProperty("binary", "false");
+config.addQueueConfig(queueConfig);
 ```
 
 
 Hazelcast distributed queue has one synchronous backup by default. By having this backup, when a cluster member with a queue goes down, another member having the backup of that queue will continue. Therefore, no items are lost. You can define the number of synchronous backups for a queue using the `backup-count` element in the declarative configuration. A queue can also have asynchronous backups: you can define the number of asynchronous backups using the `async-backup-count` element.
-
 
 To set the maximum size of the queue, use the `max-size` element. To purge unused or empty queues after a period of time, use the `empty-queue-ttl` element. If you define a value (time in seconds) for the `empty-queue-ttl` element, then your queue will be destroyed if it stays empty or unused for the time in seconds that you give.
 
@@ -55,6 +56,7 @@ The following is the full list of queue configuration elements with their descri
 - `item-listeners`: Adds listeners (listener classes) for the queue items. You can also set the attribute `include-value` to `true` if you want the item event to contain the item values, and you can set `local` to `true` if you want to listen to the items on the local member.
 - `queue-store`: Includes the queue store factory class name and the properties  *binary*, *memory limit* and *bulk load*. Please refer to [Queueing with Persistent Datastore](#queueing-with-persistent-datastore).
 - `statistics-enabled`: If set to `true`, you can retrieve statistics for this queue using the method `getLocalQueueStats()`.
+- `quorum-ref` : Name of quorum configuration that you want this queue to use.
 
 
 

--- a/src/Queue-Quorum.md
+++ b/src/Queue-Quorum.md
@@ -1,0 +1,21 @@
+
+### Queue split brain protection
+
+Queues can be configured to check for a minimum number of available members before applying queue operations (see [Split-Brain Protection](#split-brain-protection)). This is a check to avoid performing successful queue operations on all parts of a cluster during a network partition. 
+
+Following is a list of methods that now support quorum checks. The list is grouped by quorum type. 
+- WRITE, READ_WRITE
+    - Collection#addAll
+    - Collection#removeAll, Collection#retainAll
+    - BlockingQueue#offer, BlockingQueue#add, BlockingQueue#put
+    - BlockingQueue#drainTo
+    - IQueue#poll, Queue#remove, IQueue#take
+    - BlockingQueue#remove
+- READ,READ_WRITE
+    - Collection#clear
+    - Collection#containsAll, BlockingQueue#contains
+    - Collection#isEmpty
+    - Collection#iterator, Collection#toArray
+    - Queue#peek, Queue#element
+    - Collection#size
+    - BlockingQueue#remainingCapacity


### PR DESCRIPTION
 Extend existing quorum support to lock and queue actions. Add configuration examples, description, implementation details, gotcha's and examples. PRD : https://hazelcast.atlassian.net/wiki/display/PM/Cluster+Quorum+for+Queue+and+Lock