### PR TITLE
Add caveat on transaction isolation

### DIFF
--- a/src/Transactions.md
+++ b/src/Transactions.md
@@ -52,9 +52,10 @@ In a transaction, operations will not be executed immediately. Their changes wil
 
 For the above example, when `map.put` is executed, no data will be put in the map but the key will be locked against changes. While committing, operations will be executed, the value will be put to the map, and the key will be unlocked.
 
-The isolation level in Hazelcast Transactions is `READ_COMMITTED`. If you are in a transaction, you can read the data in your transaction and the data that is already committed. If you are not in a transaction, you can only read the committed data.
+The isolation level in Hazelcast Transactions is `READ_COMMITTED` on the level of a single partition. If you are in a transaction, you can read the data in your transaction and the data that is already committed. If you are not in a transaction, you can only read the committed data. 
 
 ![image](images/NoteSmall.jpg) ***NOTE:*** *The REPEATABLE_READ isolation level can also be exercised using the method `getForUpdate()` of `TransactionalMap`.*
+![image](images/NoteSmall.jpg) ***NOTE:*** *The isolation levels might be broken if the objects involved in the transaction span multiple partitions. A reader which is not in a transaction can then temporarily observe partially committed data. *
 
 ### Queue/Set/List vs. Map/Multimap
 


### PR DESCRIPTION
When a transaction spans multiple partitions, the user might observe
partially committed data - missing data, both old and new data, etc.

Related : https://github.com/hazelcast/hazelcast/issues/8531