### PR TITLE
EntryProcessorSampleCode.md mistype fix

### DIFF
--- a/src/EntryProcessorSampleCode.md
+++ b/src/EntryProcessorSampleCode.md
@@ -5,7 +5,7 @@
 The EntryProcessorTest class has the following methods.
 
 * `testMapEntryProcessor` puts one map entry and calls `executeOnKey` to process that map entry.
-* `testMapEntryProcessor` puts all the entries in a map and calls `executeOnEntries` to process 
+* `testMapEntryProcessorAllKeys` puts all the entries in a map and calls `executeOnEntries` to process 
    all the entries.
 
 The static class `IncrementingEntryProcessor` creates an entry processor to process the map 


### PR DESCRIPTION
Just fixed method name according to the code sample.