### PR TITLE
Updated default Cache merge policy in 3.9

### DIFF
--- a/src/JCache-SplitBrain.md
+++ b/src/JCache-SplitBrain.md
@@ -1,6 +1,6 @@
 ### JCache Split-Brain
 
-Split-Brain handling is internally supported as a service inside Hazelcast (see [Network Partitioning](#network-partitioning-split-brain-syndrome) for more details) and `JCache` uses same infrastructure with `IMap` to support Split-Brain. You can specify cache merge policy to determine which entry is used while merging. You can also provide your own cache merge policy implementations through `CacheMergePolicyInterface`.
+Split-Brain handling is internally supported as a service inside Hazelcast (see [Network Partitioning](#network-partitioning-split-brain-syndrome) for more details) and `JCache` uses same infrastructure with `IMap` to support Split-Brain. You can specify cache merge policy to determine which entry is used while merging. You can also provide your own cache merge policy by implementing `CacheMergePolicy` interface.
 
 ![image](images/NoteSmall.jpg) ***NOTE:*** *Split-Brain is only supported for heap-based JCache but not for HD-JCache, since merging a high volume of data in consistent way may cause significant performance loss on the system.*
 
@@ -38,6 +38,8 @@ There are four built-in cache merge policies:
 - **Put If Absent:** Merges cache entry from source to destination if it does not exist in the destination cache. You can specify this policy with its full class name as `com.hazelcast.cache.merge.PutIfAbsentCacheMergePolicy` or with its constant name as `PUT_IF_ABSENT`.
 - **Higher Hits:** Merges cache entry from source to destination cache if the source entry has more hits than the destination one. You can specify this policy with its full class name as `com.hazelcast.cache.merge.HigherHitsCacheMergePolicy` or with its constant name as `HIGHER_HITS`.
 - **Latest Access:** Merges cache entry from source to destination cache if the source entry has been accessed more recently than the destination entry. You can specify this policy with its full class name as `com.hazelcast.cache.merge.LatestAccessCacheMergePolicy` or with its constant name as `LATEST_ACCESS`.
+
+![image](images/NoteSmall.jpg) ***NOTE:*** *Since 3.9, the default `Cache` merge policy is put-if-absent. Up to version 3.8, the default `Cache` merge policy was pass-through.*
 
 You can access full class names or constant names of all built-in cache merge policies over `com.hazelcast.cache.BuiltInCacheMergePolicies` enum. You can specify merge policy configuration for cache declaratively or programmatically.
 

--- a/src/SplitBrainRecovery.md
+++ b/src/SplitBrainRecovery.md
@@ -129,7 +129,7 @@ Here is how merge policies are specified per cache:
         com.hazelcast.cache.merge.LatestAccessCacheMergePolicy or LATEST_ACCESS:
             The entry which has been accessed more recently wins.
 
-        Default policy is com.hazelcast.cache.merge.PassThroughCacheMergePolicy
+        Default policy is com.hazelcast.cache.merge.PutIfAbsentCacheMergePolicy
         -->
         <merge-policy>MY_MERGE_POLICY_CLASS</merge-policy>        
     </cache>


### PR DESCRIPTION
The default Cache merge policy in 3.9 is updated to "Put If Absent" merge policy by https://github.com/hazelcast/hazelcast/pull/11582.
@Serdaro we should ensure the change of default from Pass-Through to put-if-absent is documented in the release notes as well.