### PR TITLE
ZONE_AWARE update in reference manual

### DIFF
--- a/src/DurableExecutorService.md
+++ b/src/DurableExecutorService.md
@@ -47,8 +47,8 @@ config.getDurableExecutorConfig( "myDurableExecSvc" ).
  
 Following are the descriptions of each configuration element and attribute:
 
-* `name`: Name of the executor task.
-* `pool-size`: Number of executor threads per member for the executor.
-* `durability`: Durability of the executor.
-* `capacity`: Executor's task queue capacity; the number of tasks this queue can hold. 0 means Integer.MAX_VALUE.
+* `name`: Name of the executor task
+* `pool-size`: Number of executor threads per member for the executor
+* `durability`: Number of backups in the cluster for the submitted task; default is 1
+* `capacity`: Executor's task queue capacity; the number of tasks this queue can hold. 0 means Integer.MAX_VALUE
  

--- a/src/PartitionGroupConfig.md
+++ b/src/PartitionGroupConfig.md
@@ -89,7 +89,7 @@ partitionGroupConfig.setEnabled( true )
 
 **4. ZONE_AWARE:**
 
-You can use ZONE_AWARE configuration with Hazelcast jclouds or Hazelcast Azure Discovery Service plugins. 
+You can use ZONE_AWARE configuration with [Hazelcast AWS Discovery](https://github.com/hazelcast/hazelcast-aws), Hazelcast jclouds or Hazelcast Azure Discovery Service plugins. 
 
 As discovery services, these plugins put zone, rack, and host information to the Hazelcast [member attributes](#defining-member-attributes) map during the discovery process. Hazelcast creates the partition groups with respect to member attributes map entries that include zone, rack, and host information. 
 
@@ -111,7 +111,7 @@ partitionGroupConfig.setEnabled( true )
     .setGroupType( MemberGroupType.ZONE_AWARE );
 ```
 
-![image](images/NoteSmall.jpg) ***NOTE:*** *Currently ZONE_AWARE configuration works only with Hazelcast jclouds and Hazelcast Azure Discovery Service plugins. Please refer to their GitHub repositories at [Hazelcast jclouds](https://github.com/hazelcast/hazelcast-jclouds) and [Hazelcast Azure](https://github.com/hazelcast/hazelcast-azure) for more information on these plugins.* 
+ 
 
 **5. SPI:**
 


### PR DESCRIPTION
Updated documentation of ZONE_AWARE to mention now supported ZONE_AWARE for AWS Discovery. Please also check if updates regarding DurableExecutorService are still valid as for some reason, they were hidden in my repo for a long time.