### PR TITLE
Fix cluster listener registration snippets - indentation, package names, XML element names

### DIFF
--- a/src/ClusterEvents.md
+++ b/src/ClusterEvents.md
@@ -50,7 +50,7 @@ The following is an example programmatic configuration.
 ```java
 Config config = new Config();
 config.addListenerConfig(
-new ListenerConfig( "com.your-package.ClusterMembershipListener" ) );
+new ListenerConfig( "com.yourpackage.ClusterMembershipListener" ) );
 ```
 
 
@@ -61,7 +61,7 @@ The following is an example of the equivalent declarative configuration.
    ...
    <listeners>
       <listener>
-         com.your-package.ClusterMembershipListener
+         com.yourpackage.ClusterMembershipListener
       </listener>
    </listeners>
    ...
@@ -72,7 +72,7 @@ The following is an example of the equivalent Spring configuration.
 
 ```
 <hz:listeners>
- <hz:listener class-name="com.your-package.ClusterMembershipListener"/>
+ <hz:listener class-name="com.yourpackage.ClusterMembershipListener"/>
  <hz:listener implementation="MembershipListener"/>
 </hz:listeners>
 ```
@@ -135,7 +135,7 @@ The following is an example programmatic configuration.
 
 ```java
 config.addListenerConfig(
-new ListenerConfig( "com.your-package.SampleDistObjListener" ) );
+new ListenerConfig( "com.yourpackage.SampleDistObjListener" ) );
 ```
 
 
@@ -145,8 +145,8 @@ The following is an example of the equivalent declarative configuration.
 <hazelcast>
    ...
    <listeners>
-	  <listener>
-	  com.your-package.SampleDistObjListener
+      <listener>
+         com.yourpackage.SampleDistObjListener
       </listener>
    </listeners>
    ...
@@ -157,7 +157,7 @@ The following is an example of the equivalent Spring configuration.
 
 ```
 <hz:listeners>
-   <hz:listener class-name="com.your-package.SampleDistObjListener"/>
+   <hz:listener class-name="com.yourpackage.SampleDistObjListener"/>
    <hz:listener implementation="DistributedObjectListener"/>
 </hz:listeners>
 ```
@@ -219,7 +219,7 @@ The following is an example programmatic configuration.
 
 ```java
 config.addListenerConfig( 
-new ListenerConfig( "com.your-package.ClusterMigrationListener" ) );
+new ListenerConfig( "com.yourpackage.ClusterMigrationListener" ) );
 ```
 
 
@@ -229,8 +229,8 @@ The following is an example of the equivalent declarative configuration.
 <hazelcast>
    ...
    <listeners>
-	  <listener>
-	  com.your-package.ClusterMigrationListener
+      <listener>
+         com.yourpackage.ClusterMigrationListener
       </listener>
    </listeners>
    ...
@@ -241,7 +241,7 @@ The following is an example of the equivalent Spring configuration.
 
 ```
 <hz:listeners>
-   <hz:listener class-name="com.your-package.ClusterMigrationListener"/>
+   <hz:listener class-name="com.yourpackage.ClusterMigrationListener"/>
    <hz:listener implementation="MigrationListener"/>
 </hz:listeners>
 ```
@@ -296,11 +296,11 @@ The following is an example of the equivalent declarative configuration.
 ```xml
 <hazelcast>
    ...
-  <partition-lost-listeners>
-     <partition-lost-listener>
-        com.your-package.ConsoleLoggingPartitionLostListener
-     </partition-lost-listener>
- </partition-lost-listeners>
+   <listeners>
+      <listener>
+         com.yourpackage.ConsoleLoggingPartitionLostListener
+      </listener>
+   </listeners>
    ...
 </hazelcast>
 ```
@@ -351,7 +351,7 @@ The following is an example programmatic configuration.
 
 ```java
 config.addListenerConfig(
-new ListenerConfig( "com.your-package.NodeLifecycleListener" ) );
+    new ListenerConfig( "com.yourpackage.NodeLifecycleListener" ) );
 ```
 
 
@@ -361,8 +361,8 @@ The following is an example of the equivalent declarative configuration.
 <hazelcast>
    ...
    <listeners>
-	  <listener>
-	  com.your-package.NodeLifecycleListener
+      <listener>
+         com.yourpackage.NodeLifecycleListener
       </listener>
    </listeners>
    ...
@@ -373,7 +373,7 @@ The following is an example of the equivalent Spring configuration.
 
 ```
 <hz:listeners>
-   <hz:listener class-name="com.your-package.NodeLifecycleListener"/>
+   <hz:listener class-name="com.yourpackage.NodeLifecycleListener"/>
    <hz:listener implementation="LifecycleListener"/>
 </hz:listeners>
 ```
@@ -388,7 +388,7 @@ To write a client listener class, you implement the `ClientListener` interface a
 which are invoked when a client is connected to or disconnected from the cluster. You can add your client listener as shown below.
 
 ```
-hazelcast.getClientService().addClientListener(SampleClientListener);
+hazelcastInstance.getClientService().addClientListener(new SampleClientListener());
 ```
 
 The following is the equivalent declarative configuration.
@@ -396,7 +396,7 @@ The following is the equivalent declarative configuration.
 ```xml
 <listeners>
    <listener>
-      com.your-package.SampleClientListener
+      com.yourpackage.SampleClientListener
    </listener>
 </listeners>
 ```
@@ -405,8 +405,8 @@ The following is the equivalent configuration in the Spring context.
 
 ```xml
 <hz:listeners>
-   <hz:listener class-name="com.your-package.SampleClientListener"/>
-   <hz:listener implementation="com.your-package.SampleClientListener"/>
+   <hz:listener class-name="com.yourpackage.SampleClientListener"/>
+   <hz:listener implementation="com.yourpackage.SampleClientListener"/>
 </hz:listeners>
 ```
 

--- a/src/DistributedObjectEvents.md
+++ b/src/DistributedObjectEvents.md
@@ -190,7 +190,7 @@ The following is an example programmatic configuration.
 ```java
 mapConfig.addEntryListenerConfig(
 new EntryListenerConfig( "com.yourpackage.MyEntryListener", 
-		                             false, false ) );
+                                 false, false ) );
 ```
 
 
@@ -200,12 +200,12 @@ The following is an example of the equivalent declarative configuration.
 <hazelcast>
    ...
    <map name="somemap">
-   ...
+      ...
       <entry-listeners>
-	     <entry-listener include-value="false" local="false">
-		 com.your-package.MyEntryListener
-		 </entry-listener>
-	  </entry-listeners>
+         <entry-listener include-value="false" local="false">
+            com.yourpackage.MyEntryListener
+         </entry-listener>
+      </entry-listeners>
    </map>
    ...
 </hazelcast>
@@ -217,7 +217,7 @@ The following is an example of the equivalent Spring configuration.
 <hz:map name="somemap">
    <hz:entry-listeners>
       <hz:entry-listener include-value="true"
-      class-name="com.hazelcast.spring.DummyEntryListener"/>
+         class-name="com.hazelcast.spring.DummyEntryListener"/>
       <hz:entry-listener implementation="dummyEntryListener" local="true"/>
    </hz:entry-listeners>
 </hz:map>
@@ -274,8 +274,8 @@ The following is an example programmatic configuration.
 
 ```java
 multiMapConfig.addEntryListenerConfig(
-new EntryListenerConfig( "com.your-package.SampleEntryListener",
-		                             false, false ) );
+  new EntryListenerConfig( "com.yourpackage.SampleEntryListener",
+    false, false ) );
 ```
 
 
@@ -288,7 +288,7 @@ The following is an example of the equivalent declarative configuration.
       <value-collection-type>SET</value-collection-type>
       <entry-listeners>
          <entry-listener include-value="false" local="false">
-            com.your-package.SampleEntryListener
+            com.yourpackage.SampleEntryListener
          </entry-listener>
       </entry-listeners>
    </multimap>
@@ -302,7 +302,7 @@ The following is an example of the equivalent Spring configuration.
 <hz:multimap name="default" value-collection-type="LIST">
    <hz:entry-listeners>
       <hz:entry-listener include-value="false"
-         class-name="com.your-package.SampleEntryListener"/>
+         class-name="com.yourpackage.SampleEntryListener"/>
       <hz:entry-listener implementation="EntryListener" local="false"/>
    </hz:entry-listeners>
 </hz:multimap>
@@ -372,7 +372,7 @@ The following is an example programmatic configuration.
 
 ```java
 setConfig.addItemListenerConfig(
-new ItemListenerConfig( "com.your-package.SampleItemListener", true ) );
+new ItemListenerConfig( "com.yourpackage.SampleItemListener", true ) );
 ```
 
 
@@ -383,7 +383,7 @@ The following is an example of the equivalent declarative configuration.
    ...
    <item-listeners>
      <item-listener include-value="true">
-       com.your-package.SampleItemListener
+       com.yourpackage.SampleItemListener
      </item-listener>
    </item-listeners>
    ...
@@ -396,7 +396,7 @@ The following is an example of the equivalent Spring configuration.
 <hz:set name="default" >
   <hz:item-listeners>
     <hz:item-listener include-value="true"
-      class-name="com.your-package.SampleItemListener"/>
+      class-name="com.yourpackage.SampleItemListener"/>
   </hz:item-listeners>
 </hz:set>
 ```
@@ -459,7 +459,7 @@ The following is an example programmatic configuration.
 
 ```java
 topicConfig.addMessageListenerConfig(
-new ListenerConfig( "com.your-package.SampleMessageListener" ) );
+  new ListenerConfig( "com.yourpackage.SampleMessageListener" ) );
 ```
 
 
@@ -471,7 +471,7 @@ The following is an example of the equivalent declarative configuration.
    <topic name="default">
       <message-listeners>
          <message-listener>
-         com.your-package.SampleMessageListener
+            com.yourpackage.SampleMessageListener
          </message-listener>
       </message-listeners>
    </topic>   
@@ -485,7 +485,7 @@ The following is an example of the equivalent Spring configuration.
 <hz:topic name="default">
   <hz:message-listeners>
     <hz:message-listener 
-       class-name="com.your-package.SampleMessageListener"/>
+      class-name="com.yourpackage.SampleMessageListener"/>
   </hz:message-listeners>
 </hz:topic>
 ```


### PR DESCRIPTION
Issues fixed:
* removed `-` (minus) character from sample package name
* unified indentation in listener registration XML snippets
* `listener(s)` used instead of `partition-lost-listener(s)` in the `ConsoleLoggingPartitionLostListener` sample