### PR TITLE
Fix Fibonacci execution samples

### DIFF
--- a/src/ExecutionCallback.md
+++ b/src/ExecutionCallback.md
@@ -13,11 +13,8 @@ You can use the `ExecutionCallback` offered by Hazelcast to asynchronously be no
 Let's use the Fibonacci series to explain this. The example code below is the calculation that will be executed. Note that it is Callable and Serializable.
 
 ```java
-public class Fibonacci<Long> implements Callable<Long>, Serializable {
+public class Fibonacci implements Callable<Long>, Serializable {
   int input = 0;
-
-  public Fibonacci() {
-  }
 
   public Fibonacci( int input ) {
     this.input = input;

--- a/src/ExecutionCancellation.md
+++ b/src/ExecutionCancellation.md
@@ -12,11 +12,8 @@ To cancel a task, you can use the standard Java executor framework's `cancel()` 
 The Fibonacci callable class below calculates the Fibonacci number for a given number. In the `calculate` method, we check if the current thread is interrupted so that the code can respond to cancellations once the execution is started. 
 
 ```java
-public class Fibonacci<Long> implements Callable<Long>, Serializable {
+public class Fibonacci implements Callable<Long>, Serializable {
   int input = 0; 
-
-  public Fibonacci() { 
-  } 
 
   public Fibonacci( int input ) { 
     this.input = input;


### PR DESCRIPTION
This PR fixes the `Fibonacci`sample implementations in chapter 10. Distributed Computing.

The original implementation wrongly used a Long  generic type argument for the class.
Also the empty no-args constructor is removed by this PR to make the implementation simpler/shorter..