### PR TITLE
Fix DurableExecutorConfig example - int method arguments, call order

### DIFF
--- a/src/DurableExecutorService.md
+++ b/src/DurableExecutorService.md
@@ -35,14 +35,14 @@ This section presents example configurations for durable executor service along 
 **Programmatic:**
 
 ```java
-HazelcastInstance hazelcast = Hazelcast.newHazelcastInstance();
-DurableExecutorService durableExecSvc = hazelcast.getDurableExecutorService("myDurableExecSvc");
-
 Config config = new Config();
-config.getDurableExecutorConfig( "myDurableExecSvc" ).
-      .setPoolSize ( "8" )
-      .setDurability( "1" )
-      .setCapacity( "1" );
+config.getDurableExecutorConfig( "myDurableExecSvc" )
+      .setPoolSize ( 8 )
+      .setDurability( 1 )
+      .setCapacity( 1 );
+
+HazelcastInstance hazelcast = Hazelcast.newHazelcastInstance(config);
+DurableExecutorService durableExecSvc = hazelcast.getDurableExecutorService("myDurableExecSvc");
 ```
  
 Following are the descriptions of each configuration element and attribute:
@@ -50,5 +50,4 @@ Following are the descriptions of each configuration element and attribute:
 * `name`: Name of the executor task.
 * `pool-size`: Number of executor threads per member for the executor.
 * `durability`: Number of backups in the cluster for the submitted task; default is 1.
-* `capacity`: Executor's task queue capacity; the number of tasks this queue can hold. 0 means Integer.MAX_VALUE.
- 
+* `capacity`: Executor's task queue capacity; the number of tasks this queue can hold.


### PR DESCRIPTION
This PR fixes code snippet and information about capacity.

Configuring 0 as a capacity value is not allowed:
```
Exception in thread "main" java.lang.IllegalArgumentException: Capacity should be greater than 0
	at com.hazelcast.util.Preconditions.checkPositive(Preconditions.java:198)
	at com.hazelcast.config.DurableExecutorConfig.setCapacity(DurableExecutorConfig.java:156)
```