### PR TITLE
Fix EntryProcessorTest Java code - typos, filling-in generic types

### DIFF
--- a/src/EntryProcessorSampleCode.md
+++ b/src/EntryProcessorSampleCode.md
@@ -21,36 +21,35 @@ public class EntryProcessorTest {
 
   @Test
   public void testMapEntryProcessor() throws InterruptedException {
-    Config config = new Config().getMapConfig( "default" )
-        .setInMemoryFormat( MapConfig.InMemoryFormat.OBJECT );
-        
+    Config config = new Config();
+    config.getMapConfig( "default" ).setInMemoryFormat( InMemoryFormat.OBJECT );
+
     HazelcastInstance hazelcastInstance1 = Hazelcast.newHazelcastInstance( config );
     HazelcastInstance hazelcastInstance2 = Hazelcast.newHazelcastInstance( config );
     IMap<Integer, Integer> map = hazelcastInstance1.getMap( "mapEntryProcessor" );
     map.put( 1, 1 );
-    EntryProcessor entryProcessor = new IncrementingEntryProcessor();
+    EntryProcessor<Integer, Integer> entryProcessor = new IncrementingEntryProcessor();
     map.executeOnKey( 1, entryProcessor );
     assertEquals( map.get( 1 ), (Object) 2 );
-    hazelcastInstance1.getLifecycleService().shutdown();
-    hazelcastInstance2.getLifecycleService().shutdown();
+    hazelcastInstance1.shutdown();
+    hazelcastInstance2.shutdown();
   }
 
   @Test
   public void testMapEntryProcessorAllKeys() throws InterruptedException {
-    StaticNodeFactory factory = new StaticNodeFactory( 2 );
-    Config config = new Config().getMapConfig( "default" )
-        .setInMemoryFormat( MapConfig.InMemoryFormat.OBJECT );
-        
-    HazelcastInstance hazelcastInstance1 = factory.newHazelcastInstance( config );
-    HazelcastInstance hazelcastInstance2 = factory.newHazelcastInstance( config );
+    Config config = new Config();
+    config.getMapConfig( "default" ).setInMemoryFormat( InMemoryFormat.OBJECT );
+
+    HazelcastInstance hazelcastInstance1 = Hazelcast.newHazelcastInstance( config );
+    HazelcastInstance hazelcastInstance2 = Hazelcast.newHazelcastInstance( config );
     IMap<Integer, Integer> map = hazelcastInstance1
         .getMap( "mapEntryProcessorAllKeys" );
-        
+
     int size = 100;
     for ( int i = 0; i < size; i++ ) {
       map.put( i, i );
     }
-    EntryProcessor entryProcessor = new IncrementingEntryProcessor();
+    EntryProcessor<Integer, Integer> entryProcessor = new IncrementingEntryProcessor();
     Map<Integer, Object> res = map.executeOnEntries( entryProcessor );
     for ( int i = 0; i < size; i++ ) {
       assertEquals( map.get( i ), (Object) (i + 1) );
@@ -58,25 +57,25 @@ public class EntryProcessorTest {
     for ( int i = 0; i < size; i++ ) {
       assertEquals( map.get( i ) + 1, res.get( i ) );
     }
-    hazelcastInstance1.getLifecycleService().shutdown();
-    hazelcastInstance2.getLifecycleService().shutdown();
+    hazelcastInstance1.shutdown();
+    hazelcastInstance2.shutdown();
   }
 
   static class IncrementingEntryProcessor
-      implements EntryProcessor, EntryBackupProcessor, Serializable {
-      
-    public Object process( Map.Entry entry ) {
-      Integer value = (Integer) entry.getValue();
+      implements EntryProcessor<Integer, Integer>, EntryBackupProcessor<Integer, Integer>, Serializable {
+
+    public Object process( Map.Entry<Integer, Integer> entry ) {
+      Integer value = entry.getValue();
       entry.setValue( value + 1 );
       return value + 1;
     }
 
-    public EntryBackupProcessor getBackupProcessor() {
+    public EntryBackupProcessor<Integer, Integer> getBackupProcessor() {
       return IncrementingEntryProcessor.this;
     }
 
-    public void processBackup( Map.Entry entry ) {
-      entry.setValue( (Integer) entry.getValue() + 1 );
+    public void processBackup( Map.Entry<Integer, Integer> entry ) {
+      entry.setValue( entry.getValue() + 1 );
     }
   }
 }


### PR DESCRIPTION
This PR fixes `EntryProcessorTest` sample code:
- fixed typos and wrong return types
- added generic types to avoid "Raw type" compiler warnings