### PR TITLE
Improve XA transactions sample

### DIFF
--- a/src/XATransactions.md
+++ b/src/XATransactions.md
@@ -7,10 +7,17 @@ XA describes the interface between the global transaction manager and the local 
 When you implement the `XAResource` interface, Hazelcast provides XA transactions. You can obtain the `HazelcastXAResource` instance via the `HazelcastInstance getXAResource` method. You can see the
 [HazelcastXAResource source code here](https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/transaction/HazelcastXAResource.java).
 
-Below is example code that uses Atomikos for transaction management.
+Below is example code that uses JTA API for transaction management.
   
 ```java
-UserTransactionManager tm = new UserTransactionManager();
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+
+import com.hazelcast.core.*
+import com.hazelcast.transaction.HazelcastXAResource;
+import com.hazelcast.transaction.TransactionContext;
+
+TransactionManager tm = getTransactionManager(); // depends on JTA implementation
 tm.setTransactionTimeout(60);
 tm.begin();
 
@@ -27,7 +34,6 @@ try {
   map.put("key", "value");
   // other resource operations
   
-  transaction.delistResource(xaResource, XAResource.TMSUCCESS);
   tm.commit();
 } catch (Exception e) {
   tm.rollback();


### PR DESCRIPTION
* added imports - as for instance the `Transaction` lives in both Hazelcast and JTA
* removed Atomikos dependencies - let user to choose the JTA implementation (Atomikos, Narayana, ...) - by using `UserTransactionManager` we wire the Atomikos specific API into the sample
* removed `delistResource()` usage - it's only confusing in the example. The delistResource call should be used only in specific cases (see e.g. https://stackoverflow.com/a/7173868/653069)