### PR TITLE
Fix setting HAZELCAST_INSTANCE_ITSELF as JCache CacheManager property

### DIFF
--- a/daux/docs/1300_Hazelcast_JCache/600_Hazelcast_JCache_Extension-ICache/100_Scoping_to_Join_Clusters.md
+++ b/daux/docs/1300_Hazelcast_JCache/600_Hazelcast_JCache_Extension-ICache/100_Scoping_to_Join_Clusters.md
@@ -298,7 +298,7 @@ When an existing `HazelcastInstance` object is available, it can be passed to th
 HazelcastInstance instance = Hazelcast.newHazelcastInstance();
 
 Properties properties = new Properties();
-properties.setProperty( HazelcastCachingProvider.HAZELCAST_INSTANCE_ITSELF, 
+properties.put( HazelcastCachingProvider.HAZELCAST_INSTANCE_ITSELF, 
      instance );
 
 CachingProvider cachingProvider = Caching.getCachingProvider();

--- a/src/JCache-ICache.md
+++ b/src/JCache-ICache.md
@@ -306,7 +306,7 @@ When an existing `HazelcastInstance` object is available, it can be passed to th
 HazelcastInstance instance = Hazelcast.newHazelcastInstance();
 
 Properties properties = new Properties();
-properties.setProperty( HazelcastCachingProvider.HAZELCAST_INSTANCE_ITSELF, 
+properties.put( HazelcastCachingProvider.HAZELCAST_INSTANCE_ITSELF, 
      instance );
 
 CachingProvider cachingProvider = Caching.getCachingProvider();


### PR DESCRIPTION
The original `setProperty(...)` call can only be used for `String` arguments.