### PR TITLE
Fix ICache async call example snippet

### DIFF
--- a/daux/docs/1300_Hazelcast_JCache/600_Hazelcast_JCache_Extension-ICache/500_ICache_Async_Methods.md
+++ b/daux/docs/1300_Hazelcast_JCache/600_Hazelcast_JCache_Extension-ICache/500_ICache_Async_Methods.md
@@ -7,7 +7,7 @@ The asynchronous versions of the methods append the phrase `Async` to the method
 
 ```java
 ICache<Integer, String> unwrappedCache = cache.unwrap( ICache.class );
-ICompletableFuture<String> future = unwrappedCache.putAsync( 1, "value" );
+ICompletableFuture<String> future = unwrappedCache.getAndPutAsync( 1, "value" );
 future.andThen( new ExecutionCallback<String>() {
   public void onResponse( String response ) {
     System.out.println( "Previous value: " + response );

--- a/src/JCache-AsyncOperations.md
+++ b/src/JCache-AsyncOperations.md
@@ -9,7 +9,7 @@ The asynchronous versions of the methods append the phrase `Async` to the method
 
 ```java
 ICache<Integer, String> unwrappedCache = cache.unwrap( ICache.class );
-ICompletableFuture<String> future = unwrappedCache.putAsync( 1, "value" );
+ICompletableFuture<String> future = unwrappedCache.getAndPutAsync( 1, "value" );
 future.andThen( new ExecutionCallback<String>() {
   public void onResponse( String response ) {
     System.out.println( "Previous value: " + response );


### PR DESCRIPTION
The `putAsync()` returns `Void` future, let's use `getAndPutAsync()` call instead.