### PR TITLE
Fix JCache ExpiryPolicy

### DIFF
--- a/daux/docs/1300_Hazelcast_JCache/200_Setup_and_Configuration/300_Configuring_for_JCache.md
+++ b/daux/docs/1300_Hazelcast_JCache/200_Setup_and_Configuration/300_Configuring_for_JCache.md
@@ -35,7 +35,7 @@ Note that this section only describes the JCache provided standard properties. F
   <cache-writer-factory
      class-name="com.example.cache.MyCacheWriterFactory" />
   <expiry-policy-factory
-     class-name="com.example.cache.MyExpirePolicyFactory" />
+     class-name="com.example.cache.MyExpiryPolicyFactory" />
 
   <cache-entry-listeners>
     <cache-entry-listener old-value-required="false" synchronous="false">

--- a/daux/docs/1300_Hazelcast_JCache/400_JCache_API/100_JCache_API_Application_Example.md
+++ b/daux/docs/1300_Hazelcast_JCache/400_JCache_API/100_JCache_API_Application_Example.md
@@ -74,7 +74,7 @@ Let's go through this configuration line by line.
 ##### Setting the Cache Type and Expire Policy
 
 First, we set the expected types for the cache, which is already known from the previous example. On the next line, a
-`javax.cache.expiry.ExpirePolicy` is configured. Almost all integration `ExpirePolicy` implementations are configured using
+`javax.cache.expiry.ExpiryPolicy` is configured. Almost all integration `ExpiryPolicy` implementations are configured using
 `javax.cache.configuration.Factory` instances. `Factory` and `FactoryBuilder` are explained later in this chapter.
 
 ##### Configuring Read-Through and Write-Through

--- a/daux/docs/1300_Hazelcast_JCache/400_JCache_API/300_Implementing_Factory_and_FactoryBuilder.md
+++ b/daux/docs/1300_Hazelcast_JCache/400_JCache_API/300_Implementing_Factory_and_FactoryBuilder.md
@@ -1,7 +1,7 @@
 
 
 The `javax.cache.configuration.Factory` implementations configure features like
-`CacheEntryListener`, `ExpirePolicy`, and `CacheLoader`s or `CacheWriter`s. These factory implementations are required to distribute the
+`CacheEntryListener`, `ExpiryPolicy`, and `CacheLoader`s or `CacheWriter`s. These factory implementations are required to distribute the
 different features to members in a cluster environment like Hazelcast. Therefore, these factory implementations have to be serializable.
 
 `Factory` implementations are easy to do, as they follow the default Provider- or Factory-Pattern. The sample class

--- a/daux/docs/1300_Hazelcast_JCache/400_JCache_API/800_Implementing_ExpiryPolicy.md
+++ b/daux/docs/1300_Hazelcast_JCache/400_JCache_API/800_Implementing_ExpiryPolicy.md
@@ -1,5 +1,5 @@
 
-In JCache, `javax.cache.expiry.ExpirePolicy` implementations are used to automatically expire cache entries based on different rules.
+In JCache, `javax.cache.expiry.ExpiryPolicy` implementations are used to automatically expire cache entries based on different rules.
 
 Expiry timeouts are defined using `javax.cache.expiry.Duration`, which is a pair of `java.util.concurrent.TimeUnit`, that
 describes a time unit and a long, defining the timeout value. The minimum allowed `TimeUnit` is `TimeUnit.MILLISECONDS`.
@@ -14,6 +14,6 @@ By default, JCache delivers a set of predefined expiry strategies in the standar
 - `ModifiedExpiryPolicy`: Expires after a given set of time measured from creation of the cache entry. The expiry timeout is updated on updating the key.
 - `TouchedExpiryPolicy`: Expires after a given set of time measured from creation of the cache entry. The expiry timeout is updated on accessing or updating the key.
 
-Because `EternalExpirePolicy` does not expire cache entries, it is still possible to evict values from memory if an underlying
+Because `EternalExpiryPolicy` does not expire cache entries, it is still possible to evict values from memory if an underlying
 `CacheLoader` is defined.
 

--- a/daux/docs/1300_Hazelcast_JCache/600_Hazelcast_JCache_Extension-ICache/600_Defining_a_Custom_Expiry_Policy.md
+++ b/daux/docs/1300_Hazelcast_JCache/600_Hazelcast_JCache_Extension-ICache/600_Defining_a_Custom_Expiry_Policy.md
@@ -8,7 +8,7 @@ Here is how an `ExpirePolicy` is set on JCache configuration:
 ```java
 CompleteConfiguration<String, String> config =
     new MutableConfiguration<String, String>()
-        setExpiryPolicyFactory(
+        .setExpiryPolicyFactory(
             AccessedExpiryPolicy.factoryOf( Duration.ONE_MINUTE )
         );
 ```

--- a/daux/docs/1300_Hazelcast_JCache/600_Hazelcast_JCache_Extension-ICache/600_Defining_a_Custom_Expiry_Policy.md
+++ b/daux/docs/1300_Hazelcast_JCache/600_Hazelcast_JCache_Extension-ICache/600_Defining_a_Custom_Expiry_Policy.md
@@ -3,7 +3,7 @@ The JCache specification has an option to configure a single `ExpiryPolicy` per 
 offers the possibility to define a custom `ExpiryPolicy` per key by providing a set of method overloads with an `expirePolicy`
 parameter, as in the list of asynchronous methods in the [Async Methods section](04_ICache_Async_Methods). This means that you can pass custom expiry policies to a cache operation.
 
-Here is how an `ExpirePolicy` is set on JCache configuration:
+Here is how an `ExpiryPolicy` is set on JCache configuration:
 
 ```java
 CompleteConfiguration<String, String> config =
@@ -13,14 +13,14 @@ CompleteConfiguration<String, String> config =
         );
 ```
 
-To pass a custom `ExpirePolicy`, a set of overloads is provided. You can use them as shown in the following code example.
+To pass a custom `ExpiryPolicy`, a set of overloads is provided. You can use them as shown in the following code example.
 
 ```java
 ICache<Integer, String> unwrappedCache = cache.unwrap( ICache.class );
 unwrappedCache.put( 1, "value", new AccessedExpiryPolicy( Duration.ONE_DAY ) );
 ```
 
-The `ExpirePolicy` instance can be pre-created, cached, and re-used, but only for each cache instance. This is because `ExpirePolicy`
+The `ExpiryPolicy` instance can be pre-created, cached, and re-used, but only for each cache instance. This is because `ExpiryPolicy`
 implementations can be marked as `java.io.Closeable`. The following list shows the provided method overloads over `javax.cache.Cache`
 by `com.hazelcast.cache.ICache` featuring the `ExpiryPolicy` parameter:
 

--- a/documentation.index
+++ b/documentation.index
@@ -125,7 +125,7 @@ src/JCache.md
 	src/JCache-APICacheWriter.md
 	src/JCache-EP.md
 	src/JCache-CacheEntryListener.md
-	src/JCache-ExpirePolicy.md
+	src/JCache-ExpiryPolicy.md
 	src/JCache-HZInstance.md
 	src/JCache-ICache.md
 	src/JCache-RetrievingICacheInstance.md

--- a/redirect-latest-dev.js
+++ b/redirect-latest-dev.js
@@ -914,7 +914,7 @@ if ($current == $baseurl + "/docs/latest-dev/manual/html-single/index.html#cache
 	window.location = $baseurl + "/docs/latest-development/manual/html/Hazelcast_JCache/JCache_API/Implementing_CacheEntryListener.html";
 }
 if ($current == $baseurl + "/docs/latest-dev/manual/html-single/index.html#expirepolicy") {
-	window.location = $baseurl + "/docs/latest-development/manual/html/Hazelcast_JCache/JCache_API/Implementing_ExpirePolicy.html";
+	window.location = $baseurl + "/docs/latest-development/manual/html/Hazelcast_JCache/JCache_API/Implementing_ExpiryPolicy.html";
 }
 
 // Docs 'Hazelcast JCache : JCache - Hazelcast Instance Integration' subsection

--- a/redirect-latest.js
+++ b/redirect-latest.js
@@ -914,7 +914,7 @@ if ($current == $baseurl + "/docs/latest/manual/html-single/index.html#cacheentr
 	window.location = $baseurl + "/docs/latest/manual/html/Hazelcast_JCache/JCache_API/Implementing_CacheEntryListener.html";
 }
 if ($current == $baseurl + "/docs/latest/manual/html-single/index.html#expirepolicy") {
-	window.location = $baseurl + "/docs/latest/manual/html/Hazelcast_JCache/JCache_API/Implementing_ExpirePolicy.html";
+	window.location = $baseurl + "/docs/latest/manual/html/Hazelcast_JCache/JCache_API/Implementing_ExpiryPolicy.html";
 }
 
 // Docs 'Hazelcast JCache : JCache - Hazelcast Instance Integration' subsection

--- a/src/JCache-API.md
+++ b/src/JCache-API.md
@@ -81,7 +81,7 @@ Let's go through this configuration line by line.
 ##### Setting the Cache Type and Expire Policy
 
 First, we set the expected types for the cache, which is already known from the previous example. On the next line, a
-`javax.cache.expiry.ExpirePolicy` is configured. Almost all integration `ExpirePolicy` implementations are configured using
+`javax.cache.expiry.ExpiryPolicy` is configured. Almost all integration `ExpiryPolicy` implementations are configured using
 `javax.cache.configuration.Factory` instances. `Factory` and `FactoryBuilder` are explained later in this chapter.
 
 ##### Configuring Read-Through and Write-Through

--- a/src/JCache-APIFactory.md
+++ b/src/JCache-APIFactory.md
@@ -2,7 +2,7 @@
 ### Implementing Factory and FactoryBuilder
 
 The `javax.cache.configuration.Factory` implementations configure features like
-`CacheEntryListener`, `ExpirePolicy`, and `CacheLoader`s or `CacheWriter`s. These factory implementations are required to distribute the
+`CacheEntryListener`, `ExpiryPolicy`, and `CacheLoader`s or `CacheWriter`s. These factory implementations are required to distribute the
 different features to members in a cluster environment like Hazelcast. Therefore, these factory implementations have to be serializable.
 
 `Factory` implementations are easy to do, as they follow the default Provider- or Factory-Pattern. The sample class

--- a/src/JCache-CustomExpiryPolicy.md
+++ b/src/JCache-CustomExpiryPolicy.md
@@ -9,7 +9,7 @@ Here is how an `ExpirePolicy` is set on JCache configuration:
 ```java
 CompleteConfiguration<String, String> config =
     new MutableConfiguration<String, String>()
-        setExpiryPolicyFactory(
+        .setExpiryPolicyFactory(
             AccessedExpiryPolicy.factoryOf( Duration.ONE_MINUTE )
         );
 ```

--- a/src/JCache-CustomExpiryPolicy.md
+++ b/src/JCache-CustomExpiryPolicy.md
@@ -4,7 +4,7 @@ The JCache specification has an option to configure a single `ExpiryPolicy` per 
 offers the possibility to define a custom `ExpiryPolicy` per key by providing a set of method overloads with an `expirePolicy`
 parameter, as in the list of asynchronous methods in the [Async Methods section](#icache-async-methods). This means that you can pass custom expiry policies to a cache operation.
 
-Here is how an `ExpirePolicy` is set on JCache configuration:
+Here is how an `ExpiryPolicy` is set on JCache configuration:
 
 ```java
 CompleteConfiguration<String, String> config =
@@ -14,14 +14,14 @@ CompleteConfiguration<String, String> config =
         );
 ```
 
-To pass a custom `ExpirePolicy`, a set of overloads is provided. You can use them as shown in the following code example.
+To pass a custom `ExpiryPolicy`, a set of overloads is provided. You can use them as shown in the following code example.
 
 ```java
 ICache<Integer, String> unwrappedCache = cache.unwrap( ICache.class );
 unwrappedCache.put( 1, "value", new AccessedExpiryPolicy( Duration.ONE_DAY ) );
 ```
 
-The `ExpirePolicy` instance can be pre-created, cached, and re-used, but only for each cache instance. This is because `ExpirePolicy`
+The `ExpiryPolicy` instance can be pre-created, cached, and re-used, but only for each cache instance. This is because `ExpiryPolicy`
 implementations can be marked as `java.io.Closeable`. The following list shows the provided method overloads over `javax.cache.Cache`
 by `com.hazelcast.cache.ICache` featuring the `ExpiryPolicy` parameter:
 

--- a/src/JCache-ExpiryPolicy.md
+++ b/src/JCache-ExpiryPolicy.md
@@ -1,7 +1,7 @@
 
-### ExpirePolicy
+### ExpiryPolicy
 
-In JCache, `javax.cache.expiry.ExpirePolicy` implementations are used to automatically expire cache entries based on different rules.
+In JCache, `javax.cache.expiry.ExpiryPolicy` implementations are used to automatically expire cache entries based on different rules.
 
 Expiry timeouts are defined using `javax.cache.expiry.Duration`, which is a pair of `java.util.concurrent.TimeUnit`, that
 describes a time unit and a long, defining the timeout value. The minimum allowed `TimeUnit` is `TimeUnit.MILLISECONDS`.
@@ -16,6 +16,6 @@ By default, JCache delivers a set of predefined expiry strategies in the standar
 - `ModifiedExpiryPolicy`: Expires after a given set of time measured from creation of the cache entry. The expiry timeout is updated on updating the key.
 - `TouchedExpiryPolicy`: Expires after a given set of time measured from creation of the cache entry. The expiry timeout is updated on accessing or updating the key.
 
-Because `EternalExpirePolicy` does not expire cache entries, it is still possible to evict values from memory if an underlying
+Because `EternalExpiryPolicy` does not expire cache entries, it is still possible to evict values from memory if an underlying
 `CacheLoader` is defined.
 

--- a/src/JCache-JCacheConfiguration.md
+++ b/src/JCache-JCacheConfiguration.md
@@ -38,7 +38,7 @@ Note that this section only describes the JCache provided standard properties. F
   <cache-writer-factory
      class-name="com.example.cache.MyCacheWriterFactory" />
   <expiry-policy-factory
-     class-name="com.example.cache.MyExpirePolicyFactory" />
+     class-name="com.example.cache.MyExpiryPolicyFactory" />
 
   <cache-entry-listeners>
     <cache-entry-listener old-value-required="false" synchronous="false">


### PR DESCRIPTION
This PR contains 2 commits related to JCache section. 
* The first just fixes minor typo (missing dot) in an example code snippet.
* The second replaces occurrences of `ExpirePolicy` (wrong) with `ExpiryPolicy` (correct) across the manual.