### PR TITLE
remove Java from title for context integrity

### DIFF
--- a/src/JavaClient.md
+++ b/src/JavaClient.md
@@ -1,4 +1,4 @@
-# Hazelcast Java Client
+# Hazelcast Clients
 
 There are currently three ways to connect to a running Hazelcast cluster natively:
 


### PR DESCRIPTION
since context also includes .NET and C++ clients just after title itself.