### PR TITLE
Updates regarding JCache 1.1 support

### DIFF
--- a/src/JCache-Setup.md
+++ b/src/JCache-Setup.md
@@ -22,7 +22,7 @@ For Maven users, the coordinates look like the following code:
 <dependency>
   <groupId>javax.cache</groupId>
   <artifactId>cache-api</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 With other build systems, you might need to describe the coordinates in a different way.
@@ -38,7 +38,7 @@ If you use `hazelcast-all.jar`:
 <dependency>
   <groupId>com.hazelcast</groupId>
   <artifactId>hazelcast-all</artifactId>
-  <version>"your Hazelcast version, e.g. 3.7"</version>
+  <version>"your Hazelcast version, e.g. 3.10"</version>
 </dependency>
 ```
 
@@ -48,7 +48,7 @@ If you use `hazelcast.jar`:
 <dependency>
   <groupId>com.hazelcast</groupId>
   <artifactId>hazelcast</artifactId>
-  <version>"your Hazelcast version, e.g. 3.7"</version>
+  <version>"your Hazelcast version, e.g. 3.10"</version>
 </dependency>
 ```
 The users of other build systems have to adjust the definition of the dependency to their needs.
@@ -63,7 +63,7 @@ Maven snippet:
 <dependency>
   <groupId>com.hazelcast</groupId>
   <artifactId>hazelcast-client</artifactId>
-  <version>"your Hazelcast version, e.g. 3.7"</version>
+  <version>"your Hazelcast version, e.g. 3.10"</version>
 </dependency>
 ```
 

--- a/src/JCache-SpecCompliance.md
+++ b/src/JCache-SpecCompliance.md
@@ -1,20 +1,19 @@
 
 ## Testing for JCache Specification Compliance
 
-Hazelcast JCache is fully compliant with the JSR 107 TCK (Technology Compatibility Kit),and therefore is officially a JCache
+Hazelcast JCache is fully compliant with the JSR 107 TCK (Technology Compatibility Kit), and therefore is officially a JCache
 implementation. 
 
 You can test Hazelcast JCache for compliance by executing the TCK. Just perform the instructions below:
 
 
-- Checkout the TCK from <a href="https://github.com/jsr107/jsr107tck" target="_blank">https://github.com/jsr107/jsr107tck</a>.
-- Change the properties in [`pom.xml`](https://github.com/jsr107/jsr107tck/blob/master/pom.xml) as shown below.
+- Checkout branch `v1.1.0` of the TCK from <a href="https://github.com/jsr107/jsr107tck" target="_blank">https://github.com/jsr107/jsr107tck</a>.
+- Change the properties in [`pom.xml`](https://github.com/jsr107/jsr107tck/blob/master/pom.xml) as shown below. Alternatively, you can set the values of these properties directly on the maven command line without editing any files as shown in the command line example below. 
 - Run the TCK using the command `mvn clean install`. This will run the tests using an embedded Hazelcast member.
-
 
 ```xml
 <properties>
-  <jcache.version>1.1.0-SNAPSHOT</jcache.version>
+  <jcache.version>1.1.0</jcache.version>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -31,29 +30,38 @@ You can test Hazelcast JCache for compliance by executing the TCK. Just perform 
        to override with the coordinates for your implementation-->
   <implementation-groupId>com.hazelcast</implementation-groupId>
   <implementation-artifactId>hazelcast</implementation-artifactId>
-  <implementation-version>Hazelcast version to be tested (should be higher than 3.3)</implementation-version>
+  <implementation-version>3.10</implementation-version>
 
   <!-- Change the following properties to your CacheManager and
        Cache implementation. Used by the unwrap tests. -->
   <CacheManagerImpl>
-    com.hazelcast.client.cache.impl.HazelcastClientCacheManager
+    com.hazelcast.client.cache.impl.HazelcastServerCacheManager
   </CacheManagerImpl>
   <CacheImpl>com.hazelcast.cache.ICache</CacheImpl>
   <CacheEntryImpl>
     com.hazelcast.cache.impl.CacheEntry
   </CacheEntryImpl>
-
-  <!-- Change the following to point to your MBeanServer, so that
-       the TCK can resolve it. -->
-  <javax.management.builder.initial>
-    com.hazelcast.cache.impl.TCKMBeanServerBuilder
-  </javax.management.builder.initial>
-  <org.jsr107.tck.management.agentId>
-    TCKMbeanServer
-  </org.jsr107.tck.management.agentId>
-
   <!-- ################################################################# -->
 </properties>
+```
+
+Complete command line example:
+
+```bash
+$ git clone https://github.com/jsr107/jsr107tck
+(clones JSR107 TCK repository to local directory jsr107tck)
+
+$ cd jsr107tck
+
+$ git checkout v1.1.0
+(checkout v1.1.0 tag) 
+
+$ mvn -Dimplementation-groupId=com.hazelcast -Dimplementation-artifactId=hazelcast \
+     -Dimplementation-version=3.10 \
+     -DCacheManagerImpl=com.hazelcast.cache.impl.HazelcastServerCacheManager \
+     -DCacheImpl=com.hazelcast.cache.ICache -DCacheEntryImpl=com.hazelcast.cache.impl.CacheEntry \
+     clean install
+
 ```
 
 Please also see [TCK 1.1.0 User Guide](https://docs.google.com/document/u/1/d/1m8d1Z44IFGAd20bXEvT2G--vWXbxaJctk16M2rmbM24/edit#) or [TCK 1.0.0 User Guide](https://docs.google.com/document/d/1w3Ugj_oEqjMlhpCkGQOZkd9iPf955ZWHAVdZzEwYYdU/edit) for more information on the testing instructions.

--- a/src/JCache.md
+++ b/src/JCache.md
@@ -17,14 +17,31 @@ The Hazelcast JCache implementation is 100% TCK (Technology Compatibility Kit) c
 requirements.
 
 In addition to the given specification, we added some features like asynchronous versions of almost all
-operations to give the user extra power.  
+operations to give the user extra power.
 
 This chapter gives a basic understanding of how to configure your application and how to setup Hazelcast to be your JCache
 provider. It also shows examples of basic JCache usage as well as the additionally offered features that are not part of JSR-107.
 To gain a full understanding of the JCache functionality and provided guarantees of different operations, read
 the specification document (which is also the main documentation for functionality) at the specification page of <a href="https://www.jcp.org/en/jsr/detail?id=107" target="_blank">JSR-107</a>.
 
+## Supported JCache versions
 
+Two versions of the JCache specification have been released:
 
+ - The original release, version 1.0.0, was released in March 2014. Hazelcast versions 3.3.1 up to 3.9.2 (included) implement version 1.0.0 of the JCache specification. 
+ - A maintenance release, version 1.1.0 was released in December 2017. Hazelcast version 3.9.3 and higher implement JCache specification version 1.1.0.
+ 
+JCache 1.1.0 is backwards compatible with JCache 1.0.0. As a maintenance release, it introduces clarifications and bug fixes in the specification, reference implementation
+and TCK, without introducing any additional features. 
+ 
+### Upgrading from JCache 1.0.0 to 1.1.0
+ 
+When upgrading from a Hazelcast version which implements JCache 1.0.0 to a version that implements version 1.1.0 of the specification, some behavioral differences must be taken into account:
 
+ - Invoking `CacheManager.getCacheNames` on a closed `CacheManager` will return an empty iterator under JCache 1.0.0, while under JCache 1.1.0 will throw an `IllegalStateException`.
+ - Runtime type checking is removed from `CacheManager.getCache(String)`, so when using JCache 1.1.0 one may obtain a `Cache` by name even when its configured key/value types are not known.
+ - Statistics effects of `Cache.putIfAbsent` on misses and hits are properly applied when using JCache 1.1.0, while under JCache 1.0.0 misses and hits were not updated.
+ 
+Note that these behavioral differences apply on the Hazelcast member that executes the operation. Thus when performing a rolling member upgrade from a JCache 1.0.0-compliant Hazelcast version to a newer Hazelcast version that supports JCache 1.1.0, operations executed on the new members will exhibit JCache 1.1.0 behavior while those executed on old members will implement JCache 1.0.0 behavior.  
 
+The complete list of issues addressed in JCache specification version 1.1.0 is <a href="https://github.com/jsr107/jsr107spec/milestone/2?closed=1" target="_blank">available on github</a>.


### PR DESCRIPTION
- Updated section on running the TCK
- Adds information about behavioral changes in JCache 1.1 vs 1.0