### PR TITLE
Describe possibility of comma-separated principals in permissions configuration when the default permission policy is used.

### DIFF
--- a/daux/docs/2000_Security/900_Native_Client_Security.md
+++ b/daux/docs/2000_Security/900_Native_Client_Security.md
@@ -47,13 +47,13 @@ HazelcastInstance client = HazelcastClient.newHazelcastClient( clientConfig );
 
 ### Authorization
 
-Hazelcast client authorization is configured by a client permission policy. Hazelcast has a default permission policy implementation that uses permission configurations defined in the Hazelcast security configuration. Default policy permission checks are done against instance types (map, queue, etc.), instance names (map, queue, name, etc.), instance actions (put, read, remove, add, etc.), client endpoint addresses, and client principal defined by the Credentials object. Instance and principal names and endpoint addresses can be defined as wildcards(*). Please see the [Network Configuration section](/04_Setting_Up_Clusters/10_Other_Network_Configurations.md) and [Using Wildcards section](/03_Understanding_Configuration/05_Using_Wildcards.md).
+Hazelcast client authorization is configured by a client permission policy. Hazelcast has a default permission policy implementation that uses permission configurations defined in the Hazelcast security configuration. Default policy permission checks are done against instance types (map, queue, etc.), instance names (map, queue, name, etc.), instance actions (put, read, remove, add, etc.), client endpoint addresses, and client principal defined by the Credentials object. The default permission policy allows to use comma separated names in the principal attribute configuration. Instance and principal names and endpoint addresses can be defined as wildcards(*). Please see the [Network Configuration section](/04_Setting_Up_Clusters/10_Other_Network_Configurations.md) and [Using Wildcards section](/03_Understanding_Configuration/05_Using_Wildcards.md).
 
 ```xml
 <security enabled="true">
   <client-permissions>
-    <!-- Principal 'admin' from endpoint '127.0.0.1' has all permissions. -->
-    <all-permissions principal="admin">
+    <!-- Principals 'admin' and 'root' from endpoint '127.0.0.1' have all permissions. -->
+    <all-permissions principal="admin,root">
       <endpoints>
         <endpoint>127.0.0.1</endpoint>
       </endpoints>

--- a/src/NativeClientSecurity.md
+++ b/src/NativeClientSecurity.md
@@ -49,13 +49,13 @@ HazelcastInstance client = HazelcastClient.newHazelcastClient( clientConfig );
 
 ### Authorization
 
-Hazelcast client authorization is configured by a client permission policy. Hazelcast has a default permission policy implementation that uses permission configurations defined in the Hazelcast security configuration. Default policy permission checks are done against instance types (map, queue, etc.), instance names (map, queue, name, etc.), instance actions (put, read, remove, add, etc.), client endpoint addresses, and client principal defined by the Credentials object. Instance and principal names and endpoint addresses can be defined as wildcards(*). Please see the [Network Configuration section](#other-network-configurations) and [Using Wildcards section](#using-wildcards).
+Hazelcast client authorization is configured by a client permission policy. Hazelcast has a default permission policy implementation that uses permission configurations defined in the Hazelcast security configuration. Default policy permission checks are done against instance types (map, queue, etc.), instance names (map, queue, name, etc.), instance actions (put, read, remove, add, etc.), client endpoint addresses, and client principal defined by the Credentials object. The default permission policy allows to use comma separated names in the principal attribute configuration. Instance and principal names and endpoint addresses can be defined as wildcards(*). Please see the [Network Configuration section](#other-network-configurations) and [Using Wildcards section](#using-wildcards).
 
 ```xml
 <security enabled="true">
   <client-permissions>
-    <!-- Principal 'admin' from endpoint '127.0.0.1' has all permissions. -->
-    <all-permissions principal="admin">
+    <!-- Principals 'admin' and 'root' from endpoint '127.0.0.1' have all permissions. -->
+    <all-permissions principal="admin,root">
       <endpoints>
         <endpoint>127.0.0.1</endpoint>
       </endpoints>


### PR DESCRIPTION
This commit 
* adds a sentence:
  > The default permission policy allows to use comma separated names in the principal attribute configuration.
* changes the code snippet to show comma-separated principal names 