### PR TITLE
Add increasePermits to ISemaphore docs' quorum section

### DIFF
--- a/src/ISemaphore-Quorum.md
+++ b/src/ISemaphore-Quorum.md
@@ -10,6 +10,7 @@ Following is a list of methods that now support Split-Brain Protection checks. T
     - `drainPermits`
     - `init`
     - `reducePermits`
+    - `increasePermits`
     - `release`
     - `tryAcquire`
 - READ, READ_WRITE:


### PR DESCRIPTION
`ISemaphore.increasePermits()` is a new operation [introduced with 3.10](https://github.com/hazelcast/hazelcast/pull/7859).

Master PR: #519