### PR TITLE
Fixed Incorrect fragment part of url for 'multicast element' in Reference manual

### DIFF
--- a/src/docs/asciidoc/setting_up_clusters.adoc
+++ b/src/docs/asciidoc/setting_up_clusters.adoc
@@ -807,7 +807,7 @@ join.getTcpIpConfig().addMember( "10.45.67.32" ).addMember( "10.45.67.100" )
 
 The `join` element has the following sub-elements and attributes.
 
-[[multicase-element]]
+[[multicast-element]]
 ===== multicast element 
 
 The `multicast` element includes parameters to fine tune the multicast join mechanism.


### PR DESCRIPTION
Fix for issue https://github.com/hazelcast/hazelcast-reference-manual/issues/536