### PR TITLE
Fixed incorrect link for Global Event Configuration section

### DIFF
--- a/src/docs/asciidoc/dds.adoc
+++ b/src/docs/asciidoc/dds.adoc
@@ -2477,7 +2477,7 @@ Besides the above elements, there are the following system properties that are t
 * `hazelcast.event.queue.timeout.millis` with a default value of 250
 * `hazelcast.event.thread.count` with a default value of 5
 
-For a description of these parameters, please see the <<global-event-configuration, Global Event Configuration section.
+For a description of these parameters, please see the <<global-event-configuration, Global Event Configuration section>>.
 
 [[reliable-topic]]
 === Reliable Topic


### PR DESCRIPTION
Fix for issue https://github.com/hazelcast/hazelcast-reference-manual/issues/538