### PR TITLE
Mentions `setExpiryPolicy` in ICache

### DIFF
--- a/src/docs/asciidoc/jcache/icache.adoc
+++ b/src/docs/asciidoc/jcache/icache.adoc
@@ -509,6 +509,8 @@ by `com.hazelcast.cache.ICache` featuring the `ExpiryPolicy` parameter:
 
 Asynchronous method overloads are not listed here. Please see <<icache-async-methods, ICache Async Methods>> for the list of asynchronous method overloads.
 
+ICache also offers `setExpiryPolicy(key, expirePolicy)` method to associate certain keys with custom expiry policies.
+Per key expiry policies defined by this method take precedence over cache policies, but they are overridden by the expiry policies specified in above mentioned overloaded methods.
 
 ==== JCache Eviction
 


### PR DESCRIPTION
ICache section mentions overloaded methods that enable users to use custom expiry policies per call. I think we can also mention `setExpiryPolicy` method because it is also another way to use custom expiry policies that JCache does not provide.

This is a new feature introduced in 3.11