### PR TITLE
Add TLSv1.3 protocol, don't advertise SSL ones

### DIFF
--- a/src/docs/asciidoc/security.adoc
+++ b/src/docs/asciidoc/security.adoc
@@ -235,15 +235,13 @@ Here are the descriptions for the properties:
 Please see the <<mutual-authentication, Mutual Authentication section>>.
 * `ciphersuites`: Comma-separated list of cipher suite names allowed to be used. Its default value are all supported suites in your Java runtime.
 * `protocol`: Name of the algorithm which is used in your TLS/SSL. Its default value is `TLS`. Available values are:
-** TLS
-** TLSv1
-** TLSv1.1
-** TLSv1.2
-** SSL
-** SSLv2
-** SSLv3
+** `TLS`
+** `TLSv1`
+** `TLSv1.1` (from Java 8)
+** `TLSv1.2` (from Java 8)
+** `TLSv1.3` (from Java 11)
 +
-All of the above algorithms support Java 6 and higher versions, except the TLSv1.2 supports Java 7 and higher versions. For the `protocol` property, we recommend you to provide TLS with its version information, e.g., `TLSv1.2`. Note that if you write only `SSL` or `TLS`, your application will choose the SSL or TLS version according to your Java version. It is recommended to avoid using SSL protocols as they are insecure.
+For the `protocol` property, we recommend you to provide TLS with its version information, e.g., `TLSv1.2`. Note that if you write only `TLS`, your application will choose the TLS version according to your Java version.
 
 ===== Other Property Configuration Options
 
@@ -556,33 +554,31 @@ Here are the descriptions for the properties:
  trusted by your application. Its type should be `JKS`.
 * `trustStorePassword`: Password to unlock the truststore file.
 * `protocol`: Name of the algorithm which is used in your TLS/SSL. Its default value is `TLSv1.2`. Available values are:
-** SSL
-** SSLv2
-** SSLv3
-** TLS
-** TLSv1
-** TLSv1.1
-** TLSv1.2
+** `TLS`
+** `TLSv1`
+** `TLSv1.1`
+** `TLSv1.2`
+** `SSL` _(insecure!)_
+** `SSLv2` _(insecure!)_
+** `SSLv3` _(insecure!)_
 +
 All of the algorithms listed above support Java 6 and higher versions. For the `protocol` property, we recommend you to provide SSL or TLS with its version information, e.g., `TLSv1.2`. Note that if you
-provide only `SSL` or `TLS` as a value for the `protocol` property, they will be converted to `SSLv3` and `TLSv1.2`, respectively.
+provide only `SSL` or `TLS` as a value for the `protocol` property, they will be converted to `SSLv3` and `TLSv1.2`, respectively. We strongly recommend to avoid SSL protocols.
 
 
 ==== Configuring Cipher Suites
 
-To get the best performance out of OpenSSL, the correct https://en.wikipedia.org/wiki/Cipher_suite[cipher suites] need to be configured.
+To get the best performance, the correct https://en.wikipedia.org/wiki/Cipher_suite[cipher suites] need to be configured.
 Each cipher suite has different performance and security characteristics and depending on the hardware and selected cipher suite, the overhead of TLS can range from dramatic to almost negligible.
 
 The cipher suites are configured using the `ciphersuites` property as shown below:
 
 ```
 <ssl enabled="true">
-    <factory-class-name>com.hazelcast.nio.ssl.OpenSSLEngineFactory</factory-class-name>
+    <factory-class-name>...</factory-class-name>
 
     <properties>
         <property name="keyStore">upload/hazelcast.keystore</property>
-        ...
-        ...
         ...
         <property name="ciphersuites">TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
                                       TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA</property>


### PR DESCRIPTION
Java 11 comes with support for `TLSv1.3`. This PR adds it to the reference manual.

It also removes SSL protocols from list of supported values as they really should not be used (newer Java versions have them disabled - e.g. https://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider). The SSL protocols remain in OpenSSL section, but they are explicitly marked as insecure.