### PR TITLE
Improve security section related to usage of native TLS libraries (OpenSSL, BoringSSL)

### DIFF
--- a/src/docs/asciidoc/security.adoc
+++ b/src/docs/asciidoc/security.adoc
@@ -231,11 +231,11 @@ Hazelcast provides a default SSLContextFactory, `com.hazelcast.nio.ssl.BasicSSLC
 
 Here are the descriptions for the properties:
 
-* `keystore`: Path of your keystore file.
+* `keyStore`: Path of your keystore file.
 * `keyStorePassword`: Password to access the key from your keystore file.
 * `keyManagerAlgorithm`: Name of the algorithm based on which the authentication keys are provided.
 * `keyStoreType`: The type of the keystore. Its default value is `JKS`. Another commonly used type is the `PKCS12`. Available keystore/truststore types depend on your Operating system and the Java runtime.
-* `truststore`: Path of your truststore file. The file truststore is a keystore file that contains a collection of certificates trusted by your application.
+* `trustStore`: Path of your truststore file. The file truststore is a keystore file that contains a collection of certificates trusted by your application.
 * `trustStorePassword`: Password to unlock the truststore file.
 * `trustManagerAlgorithm`: Name of the algorithm based on which the trust managers are provided.
 * `trustStoreType`: The type of the truststore. Its default value is `JKS`. Another commonly used type is the `PKCS12`. Available keystore/truststore types depend on your Operating system and the Java runtime.
@@ -409,126 +409,103 @@ The property will provide a lot of logging output including the TLS/SSL handshak
 In order to use secured communication between cluster and Management Center, you have to configure the cluster, see http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#connecting-hazelcast-members-to-management-center[Connecting Hazelcast members to Management Center].
 
 
-=== Integrating OpenSSL
+=== Integrating OpenSSL / BoringSSL
 
 [blue]*Hazelcast IMDG Enterprise Feature*
 
 
 NOTE: You cannot integrate OpenSSL into Hazelcast when <<encryption, Hazelcast Encryption>> is enabled.
 
-NOTE: You currently cannot use OpenSSL integration with Hazelcast when using IBM JDK.
-
 TLS/SSL in Java is normally provided by the JRE. However, the performance overhead can be significant; even with AES intrensics
-enabled. If you are using Linux, Hazelcast provides OpenSSL integration for TLS/SSL which can provide significant performance
-improvements.
+enabled. If you are using a x86_64 system (Linux, Mac, Windows), Hazelcast supports native integration for TLS/SSL which can provide significant performance
+improvements. There are two supported native TLS/SSL libraries available through
+https://netty.io/wiki/forked-tomcat-native.html[netty-tcnative] libraries:
 
-OpenSSL can be used on clients and/or members. For best performance, it is recommended to install on a client and member and
+* OpenSSL
+** dynamically linked;
+** prerequisities: `libapr`, `openssl` packages installed on your system;
+* BoringSSL - Google managed fork of the OpenSSL
+** statically linked;
+** easier to get started with;
+** benefits: reduced code footprint, additional features
+
+The native TLS integration can be used on clients and/or members. For best performance, it is recommended to install on a client and member and
 configure the appropriate cipher suite(s).
 
-Integrating OpenSSL into Hazelcast is achieved with the following steps:
+Check https://netty.io/wiki/forked-tomcat-native.html[netty-tcnative] page
+for installation details.
 
-- Installing OpenSSL
-- Configuring Hazelcast to use OpenSSL
-- Configuring Cipher Suites
+==== Netty Libraries
 
-Below sections explain these steps.
+For the native TLS/SSL integration in Java, the https://netty.io/[Netty] library is used.
 
-==== Installing OpenSSL
+Make sure the following libraries from the Netty framework are on the classpath:
+
+* `netty-handler` and its dependencies
+* one of `tc-native` implementations
+** either BoringSSL: `netty-tcnative-boringssl-static-{tcnative_version}.jar`
+** or OpenSSL: `netty-tcnative-{tcnative_version}-{os_arch}.jar`
+
+NOTE: It is very important that the version of Netty JAR(s) corresponds to a very specific version of `netty-tcnative`. In case of doubt, the simplest thing to do is to download the `netty-<version>.tar.bz2` file from the https://netty.io/downloads.html[Netty] website and check which `netty-tcnative` version is used for that Netty release.
+
+
+==== Using BoringSSL
+
+The statically linked BoringSSL binaries are included within the `netty-tcnative` libraries. There is no need to install additional software on supported systems.
+
+Example Maven dependencies:
+
+```
+<dependencies>
+    <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-tcnative-boringssl-static</artifactId>
+        <version>2.0.12.Final</version>
+    </dependency>
+    <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>4.1.27.Final</version>
+    </dependency>
+</dependencies>
+```
+
+==== Using OpenSSL
 
 Install OpenSSL. Make sure that you are installing 1.0.1 or newer release. Please refer to its documentation at
 https://github.com/openssl/openssl/blob/master/INSTALL[github.com/openssl].
 
-On the major distributions, OpenSSL is installed by default.
-
-==== Apache Portable Runtime library
-
-Install Apache Portable Runtime library. Please refer to https://apr.apache.org/download.cgi[apr.apache.org].
+Install Apache Portable Runtime (APR) library. Please refer to https://apr.apache.org/download.cgi[apr.apache.org].
 
 For RHEL:
 
-`sudo yum -y install apr`
+`sudo yum -y install apr openssl`
 
 For Ubuntu:
 
-`sudo apt-get -y install libapr1`
+`sudo apt-get -y install libapr1 openssl`
 
-==== Netty Libraries
+For Alpine Linux:
 
-For the OpenSSL integration in Java, the https://netty.io/[Netty] library is used.
+`apk add --update apr openssl`
 
-Make sure the following libraries from the Netty framework are on the classpath:
-
-** `netty-buffer-4.1.8.Final.jar`
-** `netty-codec-4.1.8.Final.jar`
-** `netty-common-4.1.8.Final.jar`
-** `netty-buffer-4.1.8.Final.jar`
-** `netty-resolver-4.1.8.Final.jar`
-** `netty-transport-4.1.8.Final.jar`
-** `netty-tcnative-boringssl-static-1.1.33.Fork26-linux-x86_64.jar`
-
-For a Maven based project, the following snippet adds the JARs.
+Example Maven dependencies (for Linux):
 
 ```
-    <dependencies>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>1.1.33.Fork26</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-            <version>4.1.8.Final</version>
-        </dependency>
-        ...
-   </dependencies>
+<dependencies>
+    <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-tcnative-boringssl-static</artifactId>
+        <version>2.0.12.Final</version>
+        <classifier>linux-x86_64</classifier>
+    </dependency>
+    <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>4.1.27.Final</version>
+    </dependency>
+</dependencies>
 ```
-
-If your projects require a smaller set of dependencies, then instead of using the larger `netty-all` JAR from the previous snippet,
-use the following snippet which contains all the essentials JARs.
-
-```xml
-    <dependencies>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>1.1.33.Fork26</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-buffer</artifactId>
-            <version>4.1.8.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-            <version>4.1.8.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-            <version>4.1.8.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>4.1.8.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-resolver</artifactId>
-            <version>4.1.8.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport</artifactId>
-            <version>4.1.8.Final</version>
-        </dependency>
-        ...
-   </dependencies>
-```
-
-NOTE: It is very important that the version of Netty JAR(s) corresponds to a very specific version of `netty-tcnative`. In case of doubt, the simplest thing to do is to download the `netty-<version>.tar.bz2` file from the https://netty.io/downloads.html[Netty] website and check which `netty-tcnative` version is used for that Netty release.
 
 ==== Configuring Hazelcast for OpenSSL
 
@@ -543,27 +520,40 @@ using OpenSSL:
 
         <properties>
             <property name="protocol">TLSv1.2</property>
-            <property name="trustStore">hazelcast.truststore</property>
-            <property name="trustStorePassword">123456</property>
+            <property name="trustCertCollectionFile">trusted-certs.pem</property>
             <!-- If the TLS mutual authentication is not used,
-                 then the keyStore configuration is not needed on client side. -->
-            <property name="keyStore">hazelcast.keystore</property>
-            <property name="keyStorePassword">123456</property>
+                 then the key configuration is not needed on client side. -->
+            <property name="keyFile">privkey.pem</property>
+            <property name="keyCertChainFile">chain.pem</property>
         </properties>
     </ssl>
 </network>
 ```
-The configuration is almost the same as regular TLS/SSL integration. The main difference is the `OpenSSLEngineFactory` factory class.
 
-Here are the descriptions for the properties:
+The configuration is similar to a regular TLS/SSL integration. The main difference is the `OpenSSLEngineFactory` factory class and following new properties:
 
-* `keystore`: Path of your keystore file. Note that your keystore's type must be `JKS`.
+* `keyFile`: Path of your PKCS#8 key file in PEM format.
+* `keyPassword`: Password to access the key file when it's encrypted.
+* `keyCertChainFile`: Path to an X.509 certificate chain file in PEM format.
+* `trustCertCollectionFile`: Path to an X.509 certificate collection file in PEM format.
+
+These new properties takes precedence over keyStore and trustStore configuration.
+Using keyStores and trustStores together with OpenSSL causes problems on some Java versions, therefor we recommend to use the OpenSSL native way.
+
+Other supported properties are:
+
+* `keyStore`: Path of your keystore file.
+** _Using the `keyStore` property is not recommended, use `keyFile` and `keyCertChainFile` instead_
 * `keyStorePassword`: Password to access the key from your keystore file.
+* `keyStoreType`: The type of the keystore. Its default value is `JKS`. Another commonly used type is the `PKCS12`. Available keystore/truststore types depend on your Operating system and the Java runtime.
 * `keyManagerAlgorithm`: Name of the algorithm based on which the authentication keys are provided.
 * `trustManagerAlgorithm`: Name of the algorithm based on which the trust managers are provided.
-* `truststore`: Path of your truststore file. The file truststore is a keystore file that contains a collection of certificates
+* `trustStore`: Path of your truststore file. The file truststore is a keystore file that contains a collection of certificates
  trusted by your application. Its type should be `JKS`.
+ ** _Using the `trustStore` property is not recommended, use `trustCertCollectionFile` instead_
 * `trustStorePassword`: Password to unlock the truststore file.
+* `trustStoreType`: The type of the keystore. Its default value is `JKS`. Another commonly used type is the `PKCS12`. Available keystore/truststore types depend on your Operating system and the Java runtime.
+* `ciphersuites`: Comma-separated list of cipher suite names allowed to be used.
 * `protocol`: Name of the algorithm which is used in your TLS/SSL. Its default value is `TLSv1.2`. Available values are:
 ** `TLS`
 ** `TLSv1`

--- a/src/docs/asciidoc/security.adoc
+++ b/src/docs/asciidoc/security.adoc
@@ -234,11 +234,11 @@ Here are the descriptions for the properties:
 * `keyStore`: Path of your keystore file.
 * `keyStorePassword`: Password to access the key from your keystore file.
 * `keyManagerAlgorithm`: Name of the algorithm based on which the authentication keys are provided.
-* `keyStoreType`: The type of the keystore. Its default value is `JKS`. Another commonly used type is the `PKCS12`. Available keystore/truststore types depend on your Operating system and the Java runtime.
+* `keyStoreType`: Type of the keystore. Its default value is `JKS`. Another commonly used type is the `PKCS12`. Available keystore/truststore types depend on your Operating system and the Java runtime.
 * `trustStore`: Path of your truststore file. The file truststore is a keystore file that contains a collection of certificates trusted by your application.
 * `trustStorePassword`: Password to unlock the truststore file.
 * `trustManagerAlgorithm`: Name of the algorithm based on which the trust managers are provided.
-* `trustStoreType`: The type of the truststore. Its default value is `JKS`. Another commonly used type is the `PKCS12`. Available keystore/truststore types depend on your Operating system and the Java runtime.
+* `trustStoreType`: Type of the truststore. Its default value is `JKS`. Another commonly used type is the `PKCS12`. Available keystore/truststore types depend on your Operating system and the Java runtime.
 * `mutualAuthentication`: Mutual authentication configuration. It's empty by default which means the client side of connection is not authenticated. Available values are:
 ** `REQUIRED` - server forces usage of a trusted client certificate
 ** `OPTIONAL` - server asks for a client certificate, but it doesn't require it
@@ -537,7 +537,7 @@ The configuration is similar to a regular TLS/SSL integration. The main differen
 * `keyCertChainFile`: Path to an X.509 certificate chain file in PEM format.
 * `trustCertCollectionFile`: Path to an X.509 certificate collection file in PEM format.
 
-These new properties takes precedence over keyStore and trustStore configuration.
+These new properties take precedence over keyStore and trustStore configurations.
 Using keyStores and trustStores together with OpenSSL causes problems on some Java versions, therefor we recommend to use the OpenSSL native way.
 
 Other supported properties are:
@@ -545,14 +545,14 @@ Other supported properties are:
 * `keyStore`: Path of your keystore file.
 ** _Using the `keyStore` property is not recommended, use `keyFile` and `keyCertChainFile` instead_
 * `keyStorePassword`: Password to access the key from your keystore file.
-* `keyStoreType`: The type of the keystore. Its default value is `JKS`. Another commonly used type is the `PKCS12`. Available keystore/truststore types depend on your Operating system and the Java runtime.
+* `keyStoreType`: Type of the keystore. Its default value is `JKS`. Another commonly used type is the `PKCS12`. Available keystore/truststore types depend on your Operating system and the Java runtime.
 * `keyManagerAlgorithm`: Name of the algorithm based on which the authentication keys are provided.
 * `trustManagerAlgorithm`: Name of the algorithm based on which the trust managers are provided.
 * `trustStore`: Path of your truststore file. The file truststore is a keystore file that contains a collection of certificates
  trusted by your application. Its type should be `JKS`.
  ** _Using the `trustStore` property is not recommended, use `trustCertCollectionFile` instead_
 * `trustStorePassword`: Password to unlock the truststore file.
-* `trustStoreType`: The type of the keystore. Its default value is `JKS`. Another commonly used type is the `PKCS12`. Available keystore/truststore types depend on your Operating system and the Java runtime.
+* `trustStoreType`: Type of the truststore. Its default value is `JKS`. Another commonly used type is the `PKCS12`. Available keystore/truststore types depend on your Operating system and the Java runtime.
 * `ciphersuites`: Comma-separated list of cipher suite names allowed to be used.
 * `protocol`: Name of the algorithm which is used in your TLS/SSL. Its default value is `TLSv1.2`. Available values are:
 ** `TLS`


### PR DESCRIPTION
This PR improves OpenSSL related content and describes changes introduced in hazelcast/hazelcast-enterprise#2398 (not yet merged!):
* OpenSSL native configuration way using PKCS#8 key files is preferred
