### PR TITLE
Fix partition count in Merkle tables

### DIFF
--- a/src/docs/asciidoc/wan.adoc
+++ b/src/docs/asciidoc/wan.adoc
@@ -812,28 +812,28 @@ The table below shows a few examples for what the memory overhead could be.
 |453 MB
 
 |10M
-|5001
+|5009
 |4
 |10
 |577 MB
 
 |10M
-|5001
+|5009
 |1
 |12
-|899 MB
+|900 MB
 
 |25M
-|5001
+|5009
 |10
 |10
-|1983 MB
+|1986 MB
 
 |25M
-|5001
+|5009
 |1
 |13
-|2735 MB
+|2740 MB
 
 |===
 
@@ -861,7 +861,7 @@ efficiency of the Merkle tree based synchronization compared to the default sync
 |10M
 |5M
 |11
-|684 MB
+|685 MB
 |2
 |10M
 |0%
@@ -869,7 +869,7 @@ efficiency of the Merkle tree based synchronization compared to the default sync
 |10M
 |5M
 |12
-|899 MB
+|900 MB
 |1
 |5M
 |100%
@@ -885,7 +885,7 @@ efficiency of the Merkle tree based synchronization compared to the default sync
 |10M
 |10K
 |8
-|496 MB
+|497 MB
 |16
 |160K
 |6150%
@@ -893,7 +893,7 @@ efficiency of the Merkle tree based synchronization compared to the default sync
 |10M
 |10K
 |12
-|899 MB
+|900 MB
 |1
 |1K
 |99900%
@@ -903,7 +903,7 @@ efficiency of the Merkle tree based synchronization compared to the default sync
 As shown in the last two rows, the Merkle tree based synchronization transfers significantly less entries than what the
 default mechanism does even with 8 deep trees. The efficiency with depth 12 is even better but consumes much more memory.
 
-NOTE: The averages in the table are calculated with 5001 partitions.
+NOTE: The averages in the table are calculated with 5009 partitions.
 
 NOTE: The average entries per leaf number above assumes perfect distribution of the entries amongst the leaves. Since this is
 typically not true in real-life scenarios the efficiency can be slightly worse. The statistics section below describes how to


### PR DESCRIPTION
Examples in the Merkle based synchronization tables were calculated with partition count `5001`. `5001` is not a prime, `5009` should have been used instead.