### PR TITLE
Use https for docs.hazelcast.org links, fix Spring integration anchor

### DIFF
--- a/src/docs/asciidoc/attributes.adoc
+++ b/src/docs/asciidoc/attributes.adoc
@@ -1,5 +1,5 @@
-:imdg-javadoc: http://docs.hazelcast.org/docs/latest-dev/javadoc
+:imdg-javadoc: https://docs.hazelcast.org/docs/latest-dev/javadoc
 :imdg-samples: https://github.com/hazelcast/hazelcast-code-samples
 :imdg-core: https://github.com/hazelcast/hazelcast/tree/master/hazelcast/src/main/java/com/hazelcast
-:hz-refman: http://docs.hazelcast.org/docs/latest/manual/html-single/index.html
-:jet-refman: http://docs.hazelcast.org/docs/jet/latest/manual/
+:hz-refman: https://docs.hazelcast.org/docs/latest/manual/html-single/index.html
+:jet-refman: https://docs.hazelcast.org/docs/jet/latest/manual/

--- a/src/docs/asciidoc/dds.adoc
+++ b/src/docs/asciidoc/dds.adoc
@@ -142,7 +142,7 @@ include::{javasource}/SampleDOL.java[tag=sampledol]
 Hazelcast Map (`IMap`) extends the interface `java.util.concurrent.ConcurrentMap` and hence `java.util.Map`. It is the distributed implementation of Java map. You can perform operations like reading and writing from/to a Hazelcast map with the well known get and put methods.
 
 '''
-NOTE: IMap data structure can also be used by https://jet.hazelcast.org/[Hazelcast Jet] for Real-Time Stream Processing (by enabling the Event Journal on your map) and Fast Batch Processing. Hazelcast Jet uses IMap as a source (reads data from IMap) and as a sink (writes data to IMap). Please see the https://jet.hazelcast.org/use-cases/fast-batch-processing/[Fast Batch Processing] and https://jet.hazelcast.org/use-cases/real-time-stream-processing/[Real-Time Stream Processing] use cases for Hazelcast Jet. Please also see http://docs.hazelcast.org/docs/jet/latest/manual/#connector-imdg[here] in the Hazelcast Jet Reference Manual to learn how Jet uses IMap, i.e., how it can read from and write to IMap.
+NOTE: IMap data structure can also be used by https://jet.hazelcast.org/[Hazelcast Jet] for Real-Time Stream Processing (by enabling the Event Journal on your map) and Fast Batch Processing. Hazelcast Jet uses IMap as a source (reads data from IMap) and as a sink (writes data to IMap). Please see the https://jet.hazelcast.org/use-cases/fast-batch-processing/[Fast Batch Processing] and https://jet.hazelcast.org/use-cases/real-time-stream-processing/[Real-Time Stream Processing] use cases for Hazelcast Jet. Please also see https://docs.hazelcast.org/docs/jet/latest/manual/#connector-imdg[here] in the Hazelcast Jet Reference Manual to learn how Jet uses IMap, i.e., how it can read from and write to IMap.
 
 
 [[getting-a-map-and-putting-an-entry]]
@@ -612,7 +612,7 @@ When a `MapStore` implementation is provided, an entry is also put into a user d
 NOTE: Data store needs to be a centralized system that is
 accessible from all Hazelcast members. Persistence to a local file system is not supported.
 
-NOTE: Also note that the `MapStore` interface extends the `MapLoader` interface as you can see in the interface http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/MapStore.html[code].
+NOTE: Also note that the `MapStore` interface extends the `MapLoader` interface as you can see in the interface https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/MapStore.html[code].
 
 NOTE: Starting with Hazelcast IMDG 3.11, all loads can be listened via `EntryLoadedListener`.
 
@@ -726,7 +726,7 @@ mapStoreConfig.setFactoryImplementation( new MapStoreFactory<Object, Object>() {
 });
 ----
 
-To initialize the `MapLoader` implementation with the given map name, configuration properties and the Hazelcast instance, implement the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/MapLoaderLifecycleSupport.html[`MapLoaderLifecycleSupport` interface]. This interface has the methods `init()` and `destroy()`.
+To initialize the `MapLoader` implementation with the given map name, configuration properties and the Hazelcast instance, implement the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/MapLoaderLifecycleSupport.html[`MapLoaderLifecycleSupport` interface]. This interface has the methods `init()` and `destroy()`.
 
 The method `init()` initializes the `MapLoader` implementation. Hazelcast calls this method when the map is first used on the Hazelcast instance. The `MapLoader` implementation can initialize the required resources for implementing `MapLoader` such as reading a configuration file or creating a database connection.
 
@@ -739,7 +739,7 @@ To pre-populate the in-memory map when the map is first touched/used, use the `M
 
 If `MapLoader.loadAllKeys` returns NULL, then nothing will be loaded. Your `MapLoader.loadAllKeys` implementation can return all or some of the keys. For example, you may select and return only the keys which are most important to you that you want to load them while initializing the map. `MapLoader.loadAllKeys` is the fastest way of pre-populating the map since Hazelcast will optimize the loading process by having each cluster member load its owned portion of the entries.
 
-The `InitialLoadMode` configuration parameter in the class http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/config/MapStoreConfig.html[MapStoreConfig] has two values: `LAZY` and `EAGER`. If `InitialLoadMode` is set to `LAZY`, data is not loaded during the map creation. If it is set to `EAGER`, all the data is loaded while the map is created and everything becomes ready to use. Also, if you add indices to your map with the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/config/MapIndexConfig.html[MapIndexConfig] class or the <<indexing-queries, `addIndex`>> method, then `InitialLoadMode` is overridden and `MapStoreConfig` behaves as if `EAGER` mode is on.
+The `InitialLoadMode` configuration parameter in the class https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/config/MapStoreConfig.html[MapStoreConfig] has two values: `LAZY` and `EAGER`. If `InitialLoadMode` is set to `LAZY`, data is not loaded during the map creation. If it is set to `EAGER`, all the data is loaded while the map is created and everything becomes ready to use. Also, if you add indices to your map with the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/config/MapIndexConfig.html[MapIndexConfig] class or the <<indexing-queries, `addIndex`>> method, then `InitialLoadMode` is overridden and `MapStoreConfig` behaves as if `EAGER` mode is on.
 
 Here is the `MapLoader` initialization flow:
 
@@ -1058,7 +1058,7 @@ Interceptors are different from listeners. With listeners, you take an action af
 
 Map interceptors are chained, so adding the same interceptor multiple times to the same map can result in duplicate effects. This can easily happen when the interceptor is added to the map at member initialization, so that each member adds the same interceptor. When you add the interceptor in this way, be sure to implement the `hashCode()` method to return the same value for every instance of the interceptor. It is not strictly necessary, but it is a good idea to also implement `equals()` as this will ensure that the map interceptor can be removed reliably.
 
-The IMap API has two methods for adding and removing an interceptor to the map: `addInterceptor` and `removeInterceptor`. Please also refer to the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/map/MapInterceptor.html[`MapInterceptor` interface] to see the methods used to intercept the changes in a map.
+The IMap API has two methods for adding and removing an interceptor to the map: `addInterceptor` and `removeInterceptor`. Please also refer to the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/map/MapInterceptor.html[`MapInterceptor` interface] to see the methods used to intercept the changes in a map.
 
 The following is an example usage.
 
@@ -1459,7 +1459,7 @@ TransactionalMultiMap:
 
 **Configuring Split-Brain Protection**
 
-Split-Brain protection for MultiMap can be configured programmatically using the method http://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/MultiMapConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
+Split-Brain protection for MultiMap can be configured programmatically using the method https://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/MultiMapConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
 
 [source,xml]
 ----
@@ -1573,7 +1573,7 @@ TransactionalSet:
 
 **Configuring Split-Brain Protection**
 
-Split-Brain protection for ISet can be configured programmatically using the method http://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/SetConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
+Split-Brain protection for ISet can be configured programmatically using the method https://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/SetConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
 
 [source,xml]
 ----
@@ -1598,7 +1598,7 @@ Hazelcast List (IList) is similar to Hazelcast Set, but Hazelcast List also allo
 
 
 '''
-NOTE: While IMap and ICache are the recommended data structures to be used by https://jet.hazelcast.org/[Hazelcast Jet], IList can also be used by it for unit testing or similar non-production situations. Please see http://docs.hazelcast.org/docs/jet/latest/manual/#imdg-list[here] in the Hazelcast Jet Reference Manual to learn how Jet can use IList, e.g., how it can fill IList with data, consume it in a Jet job and drain the results to another IList. Please also see the https://jet.hazelcast.org/use-cases/fast-batch-processing/[Fast Batch Processing] and https://jet.hazelcast.org/use-cases/real-time-stream-processing/[Real-Time Stream Processing] use cases for Hazelcast Jet.
+NOTE: While IMap and ICache are the recommended data structures to be used by https://jet.hazelcast.org/[Hazelcast Jet], IList can also be used by it for unit testing or similar non-production situations. Please see https://docs.hazelcast.org/docs/jet/latest/manual/#imdg-list[here] in the Hazelcast Jet Reference Manual to learn how Jet can use IList, e.g., how it can fill IList with data, consume it in a Jet job and drain the results to another IList. Please also see the https://jet.hazelcast.org/use-cases/fast-batch-processing/[Fast Batch Processing] and https://jet.hazelcast.org/use-cases/real-time-stream-processing/[Real-Time Stream Processing] use cases for Hazelcast Jet.
 
 [[getting-a-list-and-putting-items]]
 ==== Getting a List and Putting Items
@@ -1698,7 +1698,7 @@ TransactionalList:
 
 **Configuring Split-Brain Protection**
 
-Split-Brain protection for IList can be configured programmatically using the method http://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/ListConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
+Split-Brain protection for IList can be configured programmatically using the method https://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/ListConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
 
 [source,xml]
 ----
@@ -2098,7 +2098,7 @@ include::{javasource}/dds/topic/TopicStats.java[tag=ts]
 
 You can disable this feature with topic configuration. Please see the <<configuring-topic, Configuring Topic section>>.
 
-NOTE: These statistics values can be also viewed in Management Center. Please see the http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#monitoring-topics[Monitoring Topics section] in Hazelcast Management Center Reference Manual.
+NOTE: These statistics values can be also viewed in Management Center. Please see the https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#monitoring-topics[Monitoring Topics section] in Hazelcast Management Center Reference Manual.
 
 [[understanding-topic-behavior]]
 ==== Understanding Topic Behavior
@@ -2590,7 +2590,7 @@ IAtomicLong can be configured to check for a minimum number of available members
 
 **Configuring Split-Brain Protection**
 
-Split-Brain protection for IAtomicLong can be configured programmatically using the method http://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/AtomicLongConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
+Split-Brain protection for IAtomicLong can be configured programmatically using the method https://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/AtomicLongConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
 
 [source,xml]
 ----
@@ -2715,7 +2715,7 @@ Following is a list of methods that now support Split-Brain Protection checks. T
 
 **Configuring Split-Brain Protection**
 
-Split-Brain protection for ISemaphore can be configured programmatically using the method http://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/SemaphoreConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
+Split-Brain protection for ISemaphore can be configured programmatically using the method https://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/SemaphoreConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
 
 [source,xml]
 ----
@@ -2799,7 +2799,7 @@ Following is a list of methods that now support Split-Brain Protection checks. T
 
 **Configuring Split-Brain Protection**
 
-Split-Brain protection for IAtomicReference can be configured programmatically using the method http://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/AtomicReferenceConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
+Split-Brain protection for IAtomicReference can be configured programmatically using the method https://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/AtomicReferenceConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
 
 [source,xml]
 ----
@@ -2868,7 +2868,7 @@ Following is a list of methods that now support Split-Brain Protection checks. T
 
 **Configuring Split-Brain Protection**
 
-Split-Brain protection for ICountDownLatch can be configured programmatically using the method http://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/CountDownLatchConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
+Split-Brain protection for ICountDownLatch can be configured programmatically using the method https://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/CountDownLatchConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
 
 [source,xml]
 ----
@@ -3283,7 +3283,7 @@ Following is a list of methods that now support Split-Brain Protection checks. T
 
 **Configuring Split-Brain Protection**
 
-Split-Brain protection for Replicated Map can be configured programmatically using the method http://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/ReplicatedMapConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
+Split-Brain protection for Replicated Map can be configured programmatically using the method https://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/ReplicatedMapConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
 
 [source,xml]
 ----
@@ -3321,7 +3321,7 @@ NOTE: Objects must be serializable in a form that Hazelcast understands.
 +
 . Compute the estimate of the set so far `estimator.estimate()`.
 
-Please see the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/cardinality/CardinalityEstimator.html[cardinality estimator Javadoc] for more information on its API.
+Please see the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/cardinality/CardinalityEstimator.html[cardinality estimator Javadoc] for more information on its API.
 
 The following is an example code.
 
@@ -3347,7 +3347,7 @@ Following is a list of methods that now support Split-Brain Protection checks. T
 
 **Configuring Split-Brain Protection**
 
-Split-Brain protection for Cardinality Estimator can be configured programmatically using the method http://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/CardinalityEstimatorConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
+Split-Brain protection for Cardinality Estimator can be configured programmatically using the method https://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/CardinalityEstimatorConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
 
 [source,xml]
 ----
@@ -3365,7 +3365,7 @@ The value of `quorum-ref` should be the quorum configuration name which you conf
 **Configuring Merge Policy**
 
 While recovering from a Split-Brain syndrome, Cardinality Estimator in the small cluster merges into the bigger cluster based on a configured merge policy. When an estimator merges into the cluster, an estimator with the same name might already exist in the cluster.
-So the merge policy resolves these kinds of conflicts with different out-of-the-box strategies. It can be configured programmatically using the method http://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/CardinalityEstimatorConfig.html[`setMergePolicyConfig()`], or declaratively using the element `merge-policy`. Following is an example declarative configuration:
+So the merge policy resolves these kinds of conflicts with different out-of-the-box strategies. It can be configured programmatically using the method https://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/CardinalityEstimatorConfig.html[`setMergePolicyConfig()`], or declaratively using the element `merge-policy`. Following is an example declarative configuration:
 
 [source,xml]
 ----

--- a/src/docs/asciidoc/distributed_computing.adoc
+++ b/src/docs/asciidoc/distributed_computing.adoc
@@ -303,7 +303,7 @@ Following is a list of methods that now support Split-Brain Protection checks. T
 
 **Configuring Split-Brain Protection**
 
-Split-Brain protection for Executor Service can be configured programmatically using the method http://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/ExecutorConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
+Split-Brain protection for Executor Service can be configured programmatically using the method https://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/ExecutorConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
 
 [source,xml]
 ----
@@ -385,7 +385,7 @@ Following is a list of methods that now support Split-Brain Protection checks. T
 
 **Configuring Split-Brain Protection**
 
-Split-Brain protection for Durable Executor Service can be configured programmatically using the method http://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/DurableExecutorConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
+Split-Brain protection for Durable Executor Service can be configured programmatically using the method https://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/DurableExecutorConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
 
 [source,xml]
 ----
@@ -411,7 +411,7 @@ On top of the Vanilla Scheduling API, IScheduledExecutorService allows additiona
 * `scheduleOnAllMembers`: On all cluster members.
 * `scheduleOnAllMembers`: On all given members.
 
-Please refer to the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/scheduledexecutor/IScheduledExecutorService.html[IScheduledExecutorService Javadoc] for its API details.
+Please refer to the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/scheduledexecutor/IScheduledExecutorService.html[IScheduledExecutorService Javadoc] for its API details.
 
 There are two different modes of durability for the service:
 
@@ -425,7 +425,7 @@ The name of the task can be user-defined if it needs to be, by implementing the 
 
 Upon scheduling, the service returns an `IScheduledFuture`, which on top of the `java.util.concurrent.ScheduledFuture` functionality, provides an API to get the resource handler of the task `ScheduledTaskHandler` and also the runtime statistics of the task.
 
-Futures associated with a scheduled task, in order to be aware of lost partitions and/or members, act as listeners on the local member/client. Therefore, they are always strongly referenced, on the member/client side. In order to clean up their resources, once completed, you can use the method `dispose()`. This method will also cancel further executions of the task if scheduled at fixed rate. You can refer to the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/scheduledexecutor/IScheduledFuture.html[IScheduledFuture Javadoc] for its API details.
+Futures associated with a scheduled task, in order to be aware of lost partitions and/or members, act as listeners on the local member/client. Therefore, they are always strongly referenced, on the member/client side. In order to clean up their resources, once completed, you can use the method `dispose()`. This method will also cancel further executions of the task if scheduled at fixed rate. You can refer to the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/scheduledexecutor/IScheduledFuture.html[IScheduledFuture Javadoc] for its API details.
 
 The task handler is a descriptor class holding information for the scheduled future, which is used to pinpoint the actual task in the cluster. It contains the name of the task, the owner (member or partition) and the scheduler name.
 
@@ -525,7 +525,7 @@ Following is a list of methods that now support Split-Brain Protection checks. T
 
 **Configuring Split-Brain Protection**
 
-Split-Brain protection for Scheduled Executor Service can be configured programmatically using the method http://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/ScheduledExecutorConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
+Split-Brain protection for Scheduled Executor Service can be configured programmatically using the method https://docs.hazelcast.org/docs/3.10/javadoc/com/hazelcast/config/ScheduledExecutorConfig.html[`setQuorumName()`], or declaratively using the element `quorum-ref`. Following is an example declarative configuration:
 
 [source,xml]
 ----
@@ -549,7 +549,7 @@ If you are doing the process described above, you should consider using entry pr
 
 NOTE: Entry processor is meant to process a single entry per call. Processing multiple entries and data structures in an entry processor is not supported as it may result in deadlocks.
 
-NOTE: Note that Hazelcast Jet is a good fit when you want to perform processing that involves multiple entries (aggregations, joins, etc.), or involves multiple computing steps to be made parallel. Hazelcast Jet contains an Entry Processor Sink to allow you to update Hazelcast IMDG data as a result of your Hazelcast Jet computation. Please refer to http://docs.hazelcast.org/docs/jet/latest/manual/index.html#connector-imdg[Hazelcast Jet's Reference Manual].
+NOTE: Note that Hazelcast Jet is a good fit when you want to perform processing that involves multiple entries (aggregations, joins, etc.), or involves multiple computing steps to be made parallel. Hazelcast Jet contains an Entry Processor Sink to allow you to update Hazelcast IMDG data as a result of your Hazelcast Jet computation. Please refer to https://docs.hazelcast.org/docs/jet/latest/manual/index.html#connector-imdg[Hazelcast Jet's Reference Manual].
 
 
 ==== Performing Fast In-Memory Map Operations
@@ -571,7 +571,7 @@ NOTE: When `in-memory-format` is `OBJECT`, the old value of the updated entry wi
 
 ===== Processing Entries
 
-The methods below are in the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/IMap.html[IMap interface] for entry processing.
+The methods below are in the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/IMap.html[IMap interface] for entry processing.
 
 * `executeOnKey` processes an entry mapped by a key.
 * `executeOnKeys` processes entries mapped by a collection of keys.
@@ -580,9 +580,9 @@ The methods below are in the http://docs.hazelcast.org/docs/latest/javadoc/com/h
 * `executeOnEntries` can also process all entries in a map with a defined predicate.
 
 
-When using the `executeOnEntries` method, if the number of entries is high and you need the results, then returning null with the `process()` method is a good practice. This method is offered by the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/map/EntryProcessor.html[EntryProcessor interface]. By returning null, results of the processing is not stored in the map and thus out of memory errors are eliminated.
+When using the `executeOnEntries` method, if the number of entries is high and you need the results, then returning null with the `process()` method is a good practice. This method is offered by the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/map/EntryProcessor.html[EntryProcessor interface]. By returning null, results of the processing is not stored in the map and thus out of memory errors are eliminated.
 
-If you want to execute a task on a single key, you can also use `executeOnKeyOwner` provided by http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/IExecutorService.html#executeOnKeyOwner-java.lang.Runnable-java.lang.Object-[IExecutorService]. However, in this case you need to perform a lock and serialization.
+If you want to execute a task on a single key, you can also use `executeOnKeyOwner` provided by https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/IExecutorService.html#executeOnKeyOwner-java.lang.Runnable-java.lang.Object-[IExecutorService]. However, in this case you need to perform a lock and serialization.
 
 NOTE: Entry processors run via Operation Threads that are dedicated to specific partitions.  Therefore, with long running entry processor executions, other partition operations such as `map.put(key)` cannot be processed. With this in mind, it is a good practice to make your entry processor executions as quick as possible.
 
@@ -601,7 +601,7 @@ Therefore, if you want to to perform an entry processor execution on a single ke
 
 ===== Processing Backup Entries
 
-If your code modifies the data, then you should also provide a processor for backup entries. This is required to prevent the primary map entries from having different values than the backups because it causes the entry processor to be applied both on the primary and backup entries. The interface http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/map/EntryBackupProcessor.html[EntryBackupProcessor] offers the method `processBackup` for this purpose.
+If your code modifies the data, then you should also provide a processor for backup entries. This is required to prevent the primary map entries from having different values than the backups because it causes the entry processor to be applied both on the primary and backup entries. The interface https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/map/EntryBackupProcessor.html[EntryBackupProcessor] offers the method `processBackup` for this purpose.
 
 NOTE: It is possible that an entry processor could see that a key exists though its backup processor may not find it at the run time due to an unsent backup of a previous operation, e.g., a previous put operation. In those situations, Hazelcast internally/eventually will synchronize those owner and backup partitions so you will not lose any data. When coding an `EntryBackupProcessor`, you should take that case into account, otherwise `NullPointerException` can be seen since `Map.Entry.getValue()` may return `null`.
 
@@ -641,7 +641,7 @@ NOTE: An entry processor instance is not thread safe. If you are storing a parti
 
 You can use the `AbstractEntryProcessor` class when the same processing will be performed both on the primary and backup map entries, i.e., the same logic applies to them. If you use entry processor, you need to apply the same logic to the backup entries separately. The `AbstractEntryProcessor` class makes this primary/backup processing easier.
 
-You can use the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/map/AbstractEntryProcessor.html[`AbstractEntryProcessor` class] to create your own abstract entry processor. The method `getBackupProcessor` in this class returns an `EntryBackupProcessor` instance. This means the same processing will be applied to both the primary and backup entries. If you want to apply the processing only upon the primary entries, make the `getBackupProcessor` method return null. 
+You can use the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/map/AbstractEntryProcessor.html[`AbstractEntryProcessor` class] to create your own abstract entry processor. The method `getBackupProcessor` in this class returns an `EntryBackupProcessor` instance. This means the same processing will be applied to both the primary and backup entries. If you want to apply the processing only upon the primary entries, make the `getBackupProcessor` method return null. 
 
 NOTE: Beware of the null issue described above. Due to a yet unsent backup from a previous operation, an `EntryBackupProcessor` may temporarily receive `null` from `Map.Entry.getValue()` even though the value actually exists in the map. If you decide to use `AbstractEntryProcessor`, make sure your code logic is not sensitive to null values, or you may encounter `NullPointerException` during runtime.
 
@@ -687,7 +687,7 @@ In this case the threading looks as follows:
 . partition thread (set new value & unlock key, or just unlock key if the entry has not been modified)
 
 
-The method `getExecutorName()` method may also return two constants defined in the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/Offloadable.html[`Offloadable` interface]:
+The method `getExecutorName()` method may also return two constants defined in the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/Offloadable.html[`Offloadable` interface]:
 
 * NO_OFFLOADING: Processing will not be offloaded if the method `getExecutorName()` returns this constant; it will be executed as if it does not implement the `Offloadable` interface.
 * OFFLOADABLE_EXECUTOR: Processing will be offloaded to the default `ExecutionService.OFFLOADABLE_EXECUTOR`.

--- a/src/docs/asciidoc/distributed_query.adoc
+++ b/src/docs/asciidoc/distributed_query.adoc
@@ -109,7 +109,7 @@ characters,  (underscore) is placeholder for only one character.
 * `regex`: Checks if the result of an expression matches some regular expression.
 
 
-NOTE: Please see the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/query/Predicates.html[Predicates Javadoc] for all predicates provided.
+NOTE: Please see the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/query/Predicates.html[Predicates Javadoc] for all predicates provided.
 
 
 ===== Combining Predicates with AND, OR, NOT
@@ -272,7 +272,7 @@ values = map.values( pagingPredicate );
 
 If a comparator is not specified for `PagingPredicate`, but you want to get a collection of keys or values page by page, this collection must be an instance of `Comparable` (i.e., it must implement `java.lang.Comparable`). Otherwise, the `java.lang.IllegalArgument` exception is thrown.
 
-Starting with Hazelcast 3.6, you can also access a specific page more easily with the help of the method `setPage()`. This way, if you make a query for the hundredth page, for example, it will get all 100 pages at once instead of reaching the hundredth page one by one using the method `nextPage()`. Please note that this feature tires the memory and refer to the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/query/PagingPredicate.html[PagingPredicate Javadoc].
+Starting with Hazelcast 3.6, you can also access a specific page more easily with the help of the method `setPage()`. This way, if you make a query for the hundredth page, for example, it will get all 100 pages at once instead of reaching the hundredth page one by one using the method `nextPage()`. Please note that this feature tires the memory and refer to the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/query/PagingPredicate.html[PagingPredicate Javadoc].
 
 Paging Predicate, also known as Order & Limit, is not supported in Transactional Context.
 
@@ -637,7 +637,7 @@ and implement the `extract()` method. This method does not return any values sin
 In order to return multiple results from a single extraction, invoke the `ValueCollector.collect()` method
 multiple times, so that the collector collects all results.
 
-Please refer to the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/query/extractor/ValueExtractor.html[`ValueExtractor`] and http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/query/extractor/ValueCollector.html[`ValueCollector`] Javadocs.
+Please refer to the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/query/extractor/ValueExtractor.html[`ValueExtractor`] and https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/query/extractor/ValueCollector.html[`ValueCollector`] Javadocs.
 
 ===== ValueExtractor with Portable Serialization
 
@@ -650,7 +650,7 @@ It contains two methods:
  * `read(String path, ValueCollector<T> collector)` - enables passing all results directly to the `ValueCollector`.
  * `read(String path, ValueCallback<T> callback)` - enables filtering, transforming and grouping the result of the read operation and manually passing it to the `ValueCollector`.
 
-Please refer to the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/query/extractor/ValueReader.html[`ValueReader`] Javadoc.
+Please refer to the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/query/extractor/ValueReader.html[`ValueReader`] Javadoc.
 
 ===== Returning Multiple Values from a Single Extraction
 
@@ -940,7 +940,7 @@ Map<String, Long> result = future.get();
 
 As seen above, we create the Job instance and define a mapper, combiner and reducer. Then we submit the request to the cluster. The `submit` method returns an ICompletableFuture that can be used to attach our callbacks or to wait for the result to be processed in a blocking fashion.
 
-There are more options available for job configurations, such as defining a general chunk size or on what keys the operation will operate. For more information, please refer to the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/mapreduce/Job.html[Hazelcast source code for Job.java].
+There are more options available for job configurations, such as defining a general chunk size or on what keys the operation will operate. For more information, please refer to the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/mapreduce/Job.html[Hazelcast source code for Job.java].
 
 ===== Creating Key-Value Input Sources with KeyValueSource
 
@@ -2193,7 +2193,7 @@ There are also two callbacks:
 
 These callbacks enable releasing the state that might have been initialized and stored in the Aggregator - to reduce the network traffic.
 
-Each phase is described below and you can also refer to the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/aggregation/Aggregator.html[Aggregator Javadoc] for the API's details.
+Each phase is described below and you can also refer to the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/aggregation/Aggregator.html[Aggregator Javadoc] for the API's details.
 
 **Accumulation:**
 
@@ -2220,7 +2220,7 @@ In case of the `DoubleAverage` aggregation, the Aggregator would just divide the
 
 ==== Fast-Aggregations and Map Interfaces
 
-Fast-Aggregations are available on `com.hazelcast.core.IMap` only. IMap offers the method `aggregate` to apply the aggregation logic on the map entries. This method can be called with or without a predicate. You can refer to its http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/IMap.html#aggregate-com.hazelcast.aggregation.Aggregator-[Javadoc] to see the method details.
+Fast-Aggregations are available on `com.hazelcast.core.IMap` only. IMap offers the method `aggregate` to apply the aggregation logic on the map entries. This method can be called with or without a predicate. You can refer to its https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/IMap.html#aggregate-com.hazelcast.aggregation.Aggregator-[Javadoc] to see the method details.
 
 
 ==== Sample Implementation
@@ -2275,11 +2275,11 @@ For example, you select all employees based on some criteria, but you just want 
 
 ==== Projection API
 
-The Projection API provides the method `transform()` which is called on each result object. Its result is then gathered as the final query result entity. You can refer to the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/projection/Projection.html[Projection Javadoc] for the API's details.
+The Projection API provides the method `transform()` which is called on each result object. Its result is then gathered as the final query result entity. You can refer to the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/projection/Projection.html[Projection Javadoc] for the API's details.
 
 ===== Projections and Map Interfaces
 
-Projections are available on `com.hazelcast.core.IMap` only. IMap offers the method `project` to apply the projection logic on the map entries. This method can be called with or without a predicate. You can refer to its http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/IMap.html#project-com.hazelcast.projection.Projection-[Javadoc] to see the method details.
+Projections are available on `com.hazelcast.core.IMap` only. IMap offers the method `project` to apply the projection logic on the map entries. This method can be called with or without a predicate. You can refer to its https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/IMap.html#project-com.hazelcast.projection.Projection-[Javadoc] to see the method details.
 
 
 ==== Sample implementation

--- a/src/docs/asciidoc/extending_hazelcast.adoc
+++ b/src/docs/asciidoc/extending_hazelcast.adoc
@@ -38,7 +38,7 @@ All these features are done with the steps below. Each step adds a new functiona
 
 To have the counter as a functioning distributed object, we need a class. This class (named CounterService in the following example code) is the gateway between Hazelcast internals and the counter, allowing us to add features to the counter. The following example code creates the class `CounterService`. Its lifecycle is managed by Hazelcast. 
 
-`CounterService` should implement the interface `com.hazelcast.spi.ManagedService` as shown below. The `com.hazelcast.spi.ManagedService` http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spi/ManagedService.html[source code is here].
+`CounterService` should implement the interface `com.hazelcast.spi.ManagedService` as shown below. The `com.hazelcast.spi.ManagedService` https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spi/ManagedService.html[source code is here].
 
 `CounterService` implements the following methods. 
 
@@ -165,7 +165,7 @@ public interface Counter extends DistributedObject {
 
 ===== Implementing ManagedService and RemoteService
 
-Now, we need to make the `CounterService` class implement not only the `ManagedService` interface, but also the interface `com.hazelcast.spi.RemoteService`. This way, a client will be able to get a handle of a counter proxy. You can check the source code for RemoteService the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spi/RemoteService.html[here].
+Now, we need to make the `CounterService` class implement not only the `ManagedService` interface, but also the interface `com.hazelcast.spi.RemoteService`. This way, a client will be able to get a handle of a counter proxy. You can check the source code for RemoteService the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spi/RemoteService.html[here].
 
 [source,java]
 ----
@@ -180,7 +180,7 @@ NOTE: Note that caching and removing the proxy instance are done outside of this
 
 ===== Implementing CounterProxy
 
-Now, it is time to implement the `CounterProxy` as shown below. `CounterProxy` extends `AbstractDistributedObject`, source code is http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spi/AbstractDistributedObject.html[here]. 
+Now, it is time to implement the `CounterProxy` as shown below. `CounterProxy` extends `AbstractDistributedObject`, source code is https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spi/AbstractDistributedObject.html[here]. 
 
 [source,java]
 ----
@@ -219,7 +219,7 @@ If it is an `InterruptedException`, we have two options: either propagate the ex
 
 ===== Implementing the PartitionAwareOperation Interface
 
-Now, let's write the `IncOperation`. It implements the `PartitionAwareOperation` interface, meaning that it will be executed on the partition that hosts the counter. See the `PartitionAwareOperation` source code http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spi/PartitionAwareOperation.html[here].
+Now, let's write the `IncOperation`. It implements the `PartitionAwareOperation` interface, meaning that it will be executed on the partition that hosts the counter. See the `PartitionAwareOperation` source code https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spi/PartitionAwareOperation.html[here].
 
 The method `run` does the actual execution. Since `IncOperation` will return a response, the method `returnsResponse` returns `true`. If your method is asynchronous and does not need to return a response, it is better to return `false` since it will be faster. The actual response is stored in the field `returnValue`; retrieve it with the method `getResponse`.
 
@@ -551,7 +551,7 @@ NOTE: During a partition migration, no other operations are executed on the rela
 
 We need to make our `CounterService` class implement the `MigrationAwareService` interface. This will let Hazelcast know that the `CounterService` can perform partition migration.
 
-With the `MigrationAwareService` interface, some additional methods are exposed. For example, the method `prepareMigrationOperation` returns all the data of the partition that is going to be moved. You can check the `MigrationAwareService` source code http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spi/MigrationAwareService.html[here].
+With the `MigrationAwareService` interface, some additional methods are exposed. For example, the method `prepareMigrationOperation` returns all the data of the partition that is going to be moved. You can check the `MigrationAwareService` source code https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spi/MigrationAwareService.html[here].
 
 The method `commitMigration` commits the data, meaning that in this case, it clears the partition container of the old owner. 
 
@@ -748,7 +748,7 @@ If a backup should be made and `getSyncBackupCount` returns **3**, then three `I
 ===== Performing the Backup with IncBackupOperation
 
 Now, let's have a look at the `IncBackupOperation`. It implements `BackupOperation`, you can see the source code for `BackupOperation` 
-http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spi/BackupOperation.html[here].
+https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spi/BackupOperation.html[here].
 
 [source,java]
 ----
@@ -826,7 +826,7 @@ As it can be seen, both `IncOperation` and `IncBackupOperation` are executed. No
 
 === OperationParker
 
-`OperationParker` is an interface offered by SPI for the objects, such as Lock and Semaphore, to be used when a thread needs to wait for a lock to be released. You can see the `OperationParker` source code http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spi/impl/operationparker/OperationParker.html[here].
+`OperationParker` is an interface offered by SPI for the objects, such as Lock and Semaphore, to be used when a thread needs to wait for a lock to be released. You can see the `OperationParker` source code https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spi/impl/operationparker/OperationParker.html[here].
 
 `OperationParker` keeps a list of waiters. For each notify operation:
 

--- a/src/docs/asciidoc/faq.adoc
+++ b/src/docs/asciidoc/faq.adoc
@@ -200,7 +200,7 @@ Yes. But please note that Hazelcast's main design focus is multi-member clusters
 '''
 **How can I monitor Hazelcast?**
 
-http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html[Hazelcast Management Center] is what you use to monitor and manage the members running Hazelcast. In addition to monitoring the overall state of a cluster, you can analyze and browse data structures in detail, you can update map configurations and you can take thread dumps from members.
+https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html[Hazelcast Management Center] is what you use to monitor and manage the members running Hazelcast. In addition to monitoring the overall state of a cluster, you can analyze and browse data structures in detail, you can update map configurations and you can take thread dumps from members.
 
 You can also use Hazelcast's HTTP based health check implementation and health monitoring utility. Please see the <<health-check-and-monitoring, Health Check and Monitoring section>>. There is also a <<diagnostics, diagnostocs tool>> where you can see detailed logs enhanced with diagnostic plugins.
 
@@ -273,7 +273,7 @@ Ways of shutting down a Hazelcast member:
 ** You can call the method `HazelcastInstance.shutdown()` programatically.
 ** You can use JMX API's shutdown method. You can do this by implementing a JMX client application or using a JMX monitoring tool (like JConsole).
 ** You can set the property `hazelcast.shutdownhook.policy` to `GRACEFUL` and then shutdown by using `kill -15 <PID>`. Your member will be gracefully shutdown.
-** You can use the "Shutdown Member" button in the member view of http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#monitoring-members[Hazelcast Management Center].
+** You can use the "Shutdown Member" button in the member view of https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#monitoring-members[Hazelcast Management Center].
 
 If you use systemd's `systemctl` utility, i.e., `systemctl stop service_name`, a SIGTERM signal is sent. After 90 seconds of waiting it is followed by a SIGKILL signal by default. Thus, it will call terminate at first and kill the member directly after 90 seconds. We do not recommend to use it with its defaults. But https://www.linux.com/learn/understanding-and-using-systemd[systemd] is very customizable and well-documented, you can see its details using the command  `man systemd.kill`. If you can customize it to shutdown your Hazelcast member gracefully (by using the methods above), then you can use it.
 

--- a/src/docs/asciidoc/getting_started.adoc
+++ b/src/docs/asciidoc/getting_started.adoc
@@ -569,7 +569,7 @@ and printing the map size as **3**.
 Hazelcast also offers a tool, **Management Center**, that enables you to monitor your cluster.
 You can download it from Hazelcast website's https://hazelcast.org/download/#management-center[download page].
 You can use it to monitor your maps, queues and other distributed data structures and members. Please
-see the http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html[Hazelcast Management Center Reference Manual] for usage explanations.
+see the https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html[Hazelcast Management Center Reference Manual] for usage explanations.
 
 
 By default, Hazelcast uses multicast to discover other members that can form a cluster.  If you are

--- a/src/docs/asciidoc/hazelcast_clients.adoc
+++ b/src/docs/asciidoc/hazelcast_clients.adoc
@@ -1126,12 +1126,12 @@ The table below lists the client configuration properties with their description
 |`hazelcast.client.statistics.enabled`
 |false
 |bool
-|If set to `true`, it enables collecting the client statistics and sending them to the cluster. When it is `true` you can monitor the clients that are connected to your Hazelcast cluster, using Hazelcast Management Center. Please refer to the http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#monitoring-clients[Monitoring Clients section] in the Hazelcast Management Center Reference Manual for more information.
+|If set to `true`, it enables collecting the client statistics and sending them to the cluster. When it is `true` you can monitor the clients that are connected to your Hazelcast cluster, using Hazelcast Management Center. Please refer to the https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#monitoring-clients[Monitoring Clients section] in the Hazelcast Management Center Reference Manual for more information.
 
 |`hazelcast.client.statistics.period.seconds`
 |3
 |int
-|Period in seconds the client statistics are collected and sent to the cluster. Please refer to the http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#monitoring-clients[Monitoring Clients section] in the Hazelcast Management Center Reference Manual for more information. on the client statistics.
+|Period in seconds the client statistics are collected and sent to the cluster. Please refer to the https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#monitoring-clients[Monitoring Clients section] in the Hazelcast Management Center Reference Manual for more information. on the client statistics.
 
 |`hazelcast.client.responsequeue.idlestrategy`
 |block

--- a/src/docs/asciidoc/hazelcast_jet.adoc
+++ b/src/docs/asciidoc/hazelcast_jet.adoc
@@ -21,7 +21,7 @@ In addition to the Pipeline API, Jet also offers a distributed implementation of
 
 There is also Jet's Core API for advanced users to build custom data sources and sinks, to have a low-level control over the data flow, to fine-tune performance and build DSLs.
 
-Please see the http://docs.hazelcast.org/docs/jet/latest-dev/manual/index.html#work-with-jet[Work with Jet] section in the Hazelcast Jet Reference Manual to see a simple example.
+Please see the https://docs.hazelcast.org/docs/jet/latest-dev/manual/index.html#work-with-jet[Work with Jet] section in the Hazelcast Jet Reference Manual to see a simple example.
 
 ==== Where You Can Use It
 
@@ -59,7 +59,7 @@ A Jet job is implemented as a Hazelcast IMDG proxy, similar to the other service
 In the Hazelcast Jet world, Hazelcast IMDG can be used for data ingestion prior to processing, 
 connecting multiple Jet jobs, enriching processed events, caching the remote data, distributing Jet-processed data and running advanced data processing tasks on top of IMDG data structures.
 
-Hazelcast Jet can use Hazelcast IMDG's **IMap**, **ICache** and **IList** on the embedded cluster as sources (data structures from which Jet reads data) and sinks (data structures to which Jet writes data). IMap and ICache are partitioned data structures distributed across the cluster and Jet members can read from these structures by having each member read just its local partitions. Hazelcast IMDG's IList is stored on a single partition; all the data will be read on the single member that owns that partition. Please refer to http://docs.hazelcast.org/docs/jet/latest-dev/manual/index.html#connector-imdg[IMap and ICache] and http://docs.hazelcast.org/docs/jet/latest-dev/manual/index.html#imdg-list[IList] in the Hazelcast Jet Reference Manual to learn how Jet uses these IMDG data structures. In addition to these data structures, Jet can also process a stream of changes of IMap and ICache, using the <<event-journal, Event Journal>>.
+Hazelcast Jet can use Hazelcast IMDG's **IMap**, **ICache** and **IList** on the embedded cluster as sources (data structures from which Jet reads data) and sinks (data structures to which Jet writes data). IMap and ICache are partitioned data structures distributed across the cluster and Jet members can read from these structures by having each member read just its local partitions. Hazelcast IMDG's IList is stored on a single partition; all the data will be read on the single member that owns that partition. Please refer to https://docs.hazelcast.org/docs/jet/latest-dev/manual/index.html#connector-imdg[IMap and ICache] and https://docs.hazelcast.org/docs/jet/latest-dev/manual/index.html#imdg-list[IList] in the Hazelcast Jet Reference Manual to learn how Jet uses these IMDG data structures. In addition to these data structures, Jet can also process a stream of changes of IMap and ICache, using the <<event-journal, Event Journal>>.
 
 You can use Hazelcast Jet with embedded Hazelcast IMDG or a remote Hazelcast IMDG cluster. Benefits of using Hazelcast Jet with embedded Hazelcast IMDG are as follows:
 

--- a/src/docs/asciidoc/integrated_clustering.adoc
+++ b/src/docs/asciidoc/integrated_clustering.adoc
@@ -612,13 +612,13 @@ Please refer to Hibernate https://github.com/hazelcast/hazelcast-hibernate#confi
 
 **Sample Code**: Please see our https://github.com/hazelcast/hazelcast-code-samples/tree/master/hazelcast-integration/spring-transaction-manager[sample application] for Hazelcast Transaction Manager in our code samples repository.
 
-Starting with Hazelcast 3.7, you can get rid of the boilerplate code to begin, commit or rollback transactions by using http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spring/transaction/HazelcastTransactionManager.html[HazelcastTransactionManager]
+Starting with Hazelcast 3.7, you can get rid of the boilerplate code to begin, commit or rollback transactions by using https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spring/transaction/HazelcastTransactionManager.html[HazelcastTransactionManager]
 which is a `PlatformTransactionManager` implementation to be used with Spring Transaction API.
 
 ===== Sample Configuration for Hazelcast Transaction Manager
 
 You need to register `HazelcastTransactionManager` as your transaction manager implementation and also you need to
-register http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spring/transaction/ManagedTransactionalTaskContext.html[ManagedTransactionalTaskContext]
+register https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/spring/transaction/ManagedTransactionalTaskContext.html[ManagedTransactionalTaskContext]
 to access transactional data structures within your service class.
 
 

--- a/src/docs/asciidoc/jcache/icache.adoc
+++ b/src/docs/asciidoc/jcache/icache.adoc
@@ -10,7 +10,7 @@ It has two sets of extensions:
 
 
 '''
-NOTE: ICache data structure can also be used by https://jet.hazelcast.org/[Hazelcast Jet] for Real-Time Stream Processing (by enabling the Event Journal on your cache) and Fast Batch Processing. Hazelcast Jet uses ICache as a source (reads data from ICache) and as a sink (writes data to ICache). Please see the https://jet.hazelcast.org/use-cases/fast-batch-processing/[Fast Batch Processing] and https://jet.hazelcast.org/use-cases/real-time-stream-processing/[Real-Time Stream Processing] use cases for Hazelcast Jet. Please also see http://docs.hazelcast.org/docs/jet/latest/manual/index.html#connector-imdg[here] in the Hazelcast Jet Reference Manual to learn how Jet uses ICache, i.e., how it can read from and write to ICache.
+NOTE: ICache data structure can also be used by https://jet.hazelcast.org/[Hazelcast Jet] for Real-Time Stream Processing (by enabling the Event Journal on your cache) and Fast Batch Processing. Hazelcast Jet uses ICache as a source (reads data from ICache) and as a sink (writes data to ICache). Please see the https://jet.hazelcast.org/use-cases/fast-batch-processing/[Fast Batch Processing] and https://jet.hazelcast.org/use-cases/real-time-stream-processing/[Real-Time Stream Processing] use cases for Hazelcast Jet. Please also see https://docs.hazelcast.org/docs/jet/latest/manual/index.html#connector-imdg[here] in the Hazelcast Jet Reference Manual to learn how Jet uses ICache, i.e., how it can read from and write to ICache.
 
 ==== Scoping to Join Clusters
 
@@ -806,7 +806,7 @@ In addition to the operations explained in <<icache-async-methods, ICache Async 
  - `isDestroyed()`: Determines whether the ICache instance is destroyed or not.
  - `getLocalCacheStatistics()`: Returns a `com.hazelcast.cache.CacheStatistics` instance, both on Hazelcast members and clients, providing the same statistics data as the JMX beans.
 
-Please refer to the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/cache/ICache.html[ICache Javadoc] to see all the methods provided by ICache.
+Please refer to the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/cache/ICache.html[ICache Javadoc] to see all the methods provided by ICache.
 
 ==== Implementing BackupAwareEntryProcessor
 

--- a/src/docs/asciidoc/management.adoc
+++ b/src/docs/asciidoc/management.adoc
@@ -36,7 +36,7 @@ The following are some of the metrics that you can access via the `LocalMapStats
 * Number of get and put operations on the map (`getPutOperationCount()` and `getGetOperationCount()`).
 * Number of queries executed on the map (`getQueryCount()` and `getIndexedQueryCount()`). May be imprecise for queries involving partition predicates (`PartitionPredicate`) on off-heap storage.
 
-Please refer to http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/monitor/LocalMapStats.html[`LocalMapStats` Javadoc] to see all the metrics.
+Please refer to https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/monitor/LocalMapStats.html[`LocalMapStats` Javadoc] to see all the metrics.
 
 ==== Map Index Statistics
 
@@ -63,7 +63,7 @@ The following are some of the metrics that you can obtain via the `LocalIndexSta
 
 * Memory cost of an index (`getMemoryCost()`). For on-heap storages, this memory cost metric value is a best-effort approximation and doesn't indicate a precise on-heap memory usage of an index.
 
-Refer to http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/monitor/LocalIndexStats.html[`LocalIndexStats` Javadoc] to see all the metrics.
+Refer to https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/monitor/LocalIndexStats.html[`LocalIndexStats` Javadoc] to see all the metrics.
 
 To compute an aggregated value of `getAverageHitSelectivity()` for all cluster members, you can use a simple averaging computation as shown below:
 
@@ -107,7 +107,7 @@ This behavior applies to both client and member Near Caches.
 * Memory cost (number of bytes) of owned entries in the Near Cache (`getOwnedEntryMemoryCost()`).
 * Number of hits (reads) of the locally owned entries (`getHits()`).
 
-Please refer to http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/monitor/NearCacheStats.html[`NearCacheStats` Javadoc] to see all the metrics.
+Please refer to https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/monitor/NearCacheStats.html[`NearCacheStats` Javadoc] to see all the metrics.
 
 
 ==== Multimap Statistics
@@ -133,7 +133,7 @@ The following are some of the metrics that you can access via the `LocalMultiMap
 * Number of hits (reads) of the locally owned entries (`getHits()`).
 * Number of get and put operations on the map (`getPutOperationCount()` and `getGetOperationCount()`).
 
-Please refer to http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/monitor/LocalMultiMapStats.html[`LocalMultiMapStats` Javadoc] to see all the metrics.
+Please refer to https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/monitor/LocalMultiMapStats.html[`LocalMultiMapStats` Javadoc] to see all the metrics.
 
 
 ==== Queue Statistics
@@ -156,7 +156,7 @@ The following are some of the metrics that you can access via the `LocalQueueSta
 * Minimum and maximum ages of the items in the member (`getMinAge()` and `getMaxAge()`).
 * Number of offer, put and add operations (`getOfferOperationCount()`).
 
-Please refer to http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/monitor/LocalQueueStats.html[`LocalQueueStats` Javadoc] to see all the metrics.
+Please refer to https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/monitor/LocalQueueStats.html[`LocalQueueStats` Javadoc] to see all the metrics.
 
 
 ==== Topic Statistics
@@ -177,7 +177,7 @@ The following are the metrics that you can access via the `LocalTopicStats ` obj
 * Total number of published messages of the topic on the member (`getPublishOperationCount()`).
 * Total number of received messages of the topic on the member (`getReceiveOperationCount()`).
 
-Please refer to http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/monitor/LocalTopicStats.html[here] for its Javadoc.
+Please refer to https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/monitor/LocalTopicStats.html[here] for its Javadoc.
 
 
 ==== Executor Statistics
@@ -198,7 +198,7 @@ The following are some of the metrics that you can access via the `LocalExecutor
 * Number of started operations of the executor service (`getStartedTaskCount()`).
 * Number of completed operations of the executor service (`getCompletedTaskCount()`).
 
-Please refer to http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/monitor/LocalExecutorStats.html[`LocalExecutorStats` Javadoc] to see all the metrics.
+Please refer to https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/monitor/LocalExecutorStats.html[`LocalExecutorStats` Javadoc] to see all the metrics.
 
 === JMX API per Member
 
@@ -614,7 +614,7 @@ Starting with Hazelcast 3.6, Hazelcast introduces cluster and member states in a
 
 ===== Cluster States
 
-By changing the state of your cluster, you can allow/restrict several cluster operations or change the behavior of those operations. You can use the methods `changeClusterState()` and `shutdown()` which are in the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/Cluster.html[Cluster interface] to change your cluster's state.
+By changing the state of your cluster, you can allow/restrict several cluster operations or change the behavior of those operations. You can use the methods `changeClusterState()` and `shutdown()` which are in the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/Cluster.html[Cluster interface] to change your cluster's state.
 
 Hazelcast clusters have the following states:
 
@@ -638,7 +638,7 @@ Hazelcast clusters have the following states:
 ** If a member leaves while the cluster is in this state, the member will be removed from the partition table if cluster state moves back to `ACTIVE`.
 ** This state rejects ALL operations immediately EXCEPT the read-only operations like `map.get()` and `cache.get()`, replication and cluster heartbeat tasks.
 ** You cannot change the state of a cluster to `PASSIVE` when migration/replication tasks are being performed.
-** You can make use of `PASSIVE` state along with the <<hot-restart-persistence, Hot Restart Persistence>> feature. Please see http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/Cluster.html#shutdown--[Cluster Shutdown API] for more info.
+** You can make use of `PASSIVE` state along with the <<hot-restart-persistence, Hot Restart Persistence>> feature. Please see https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/Cluster.html#shutdown--[Cluster Shutdown API] for more info.
 * **`IN_TRANSITION`**:
 ** This state shows that the state of the cluster is in transition.
 ** You cannot set your cluster's state as `IN_TRANSITION` explicitly.
@@ -664,7 +664,7 @@ public interface Cluster {
     void shutdown(TransactionOptions transactionOptions);
 ----
 
-Please refer to the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/Cluster.html[Cluster interface] for information on these methods.
+Please refer to the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/Cluster.html[Cluster interface] for information on these methods.
 
 ===== Cluster Member States
 
@@ -724,7 +724,7 @@ The script `cluster.sh` needs the following parameters to operate according to y
 
 The script `cluster.sh` is self-documented; you can see the parameter descriptions using the command `sh cluster.sh -h` or `sh cluster.sh --help`.
 
-NOTE: You can perform the above operations using the Hot Restart tab of Hazelcast Management Center or using the REST API. Please see the http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#hot-restart[Hot Restart] and <<using-rest-api-for-cluster-management, Using REST API for Cluster Management>>.
+NOTE: You can perform the above operations using the Hot Restart tab of Hazelcast Management Center or using the REST API. Please see the https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#hot-restart[Hot Restart] and <<using-rest-api-for-cluster-management, Using REST API for Cluster Management>>.
 
 
 ===== Example Usages for cluster.sh
@@ -812,7 +812,7 @@ NOTE: Currently, this script is not supported on the Windows platforms.
 
 ==== Using REST API for Cluster Management
 
-Besides the Management Center's Hot Restart http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#hot-restart[tab] and the script <<using-the-script-cluster-sh, `cluster.sh`>>, you can also use REST API to manage your cluster's state. The following are the operations you can perform.
+Besides the Management Center's Hot Restart https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#hot-restart[tab] and the script <<using-the-script-cluster-sh, `cluster.sh`>>, you can also use REST API to manage your cluster's state. The following are the operations you can perform.
 
 [cols="5a"]
 .REST API calls
@@ -869,7 +869,7 @@ To force start the cluster when Hot Restart is enabled, use the following comman
 curl --data "${GROUPNAME}&${PASSWORD}" http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/forceStart/
 ```
 +
-NOTE: You can also perform the above operations (partialStart and forceStart) using the Hot Restart tab of Hazelcast Management Center or using the script `cluster.sh`. Please see the http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#hot-restart[Hot Restart] and <<using-the-script-cluster-sh, `cluster.sh`>>.
+NOTE: You can also perform the above operations (partialStart and forceStart) using the Hot Restart tab of Hazelcast Management Center or using the script `cluster.sh`. Please see the https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#hot-restart[Hot Restart] and <<using-the-script-cluster-sh, `cluster.sh`>>.
 +
 * _Initiating Hot Backup:_
 +
@@ -894,7 +894,7 @@ $ curl --data "dev&dev-pass&3.9" http://127.0.0.1:5701/hazelcast/rest/management
   {"status":"success","version":"3.9"}
 ```
 +
-NOTE: You can also perform the above cluster version operations using Hazelcast Management Center or using the script `cluster.sh`. Please see the http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#rolling-upgrade[Rolling Member Upgrades] and <<using-the-script-cluster-sh, `cluster.sh`>>.
+NOTE: You can also perform the above cluster version operations using Hazelcast Management Center or using the script `cluster.sh`. Please see the https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#rolling-upgrade[Rolling Member Upgrades] and <<using-the-script-cluster-sh, `cluster.sh`>>.
 |===
 
 
@@ -1500,11 +1500,11 @@ As you can see, the HEAD request only checks for a `200 OK` response. A Hazelcas
 
 Hazelcast Management Center enables you to monitor and manage your cluster members running Hazelcast. In addition to monitoring the overall state of your clusters, you can also analyze and browse your data structures in detail, update map configurations and take thread dumps from members. You can run scripts (JavaScript, Groovy, etc.) and commands on your members with its scripting and console modules.
 
-Please refer to http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html[Hazelcast Management Center Documentation] for its usage details.
+Please refer to https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html[Hazelcast Management Center Documentation] for its usage details.
 
 
 === Clustered JMX and REST via Management Center
 
 [blue]*Hazelcast IMDG Enterprise*
 
-Please refer to http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html[Hazelcast Management Center Documentation] for information on Clustered JMX and Clustered REST (via Management Center) features.
+Please refer to https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html[Hazelcast Management Center Documentation] for information on Clustered JMX and Clustered REST (via Management Center) features.

--- a/src/docs/asciidoc/performance.adoc
+++ b/src/docs/asciidoc/performance.adoc
@@ -477,7 +477,7 @@ the calling thread.
 
 The `SlowOperationDetector` monitors the operation threads and collects information about all slow operations. An `Operation` is a task executed by a generic or partition thread (see <<operation-threading, Operation Threading>>). An operation is considered as slow when it takes more computation time than the configured threshold.
 
-The `SlowOperationDetector` stores the fully qualified classname of the operation and its stacktrace as well as operation details, start time and duration of each slow invocation. All collected data is available in the http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#monitoring-members[Management Center].
+The `SlowOperationDetector` stores the fully qualified classname of the operation and its stacktrace as well as operation details, start time and duration of each slow invocation. All collected data is available in the https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#monitoring-members[Management Center].
 
 The `SlowOperationDetector` is configured via the following system properties.
 
@@ -639,7 +639,7 @@ The element `<near-cache>` has an optional attribute `name` whose default value 
 include::{javasource}/performance/NearCacheConfigurationSample.java[tag=nearcacheconfig]
 ----
 
-The class http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/config/NearCacheConfig.html[NearCacheConfig] is used for all supported Hazelcast data structures on members and clients.
+The class https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/config/NearCacheConfig.html[NearCacheConfig] is used for all supported Hazelcast data structures on members and clients.
 
 Following are the descriptions of all configuration elements:
 

--- a/src/docs/asciidoc/preface.adoc
+++ b/src/docs/asciidoc/preface.adoc
@@ -55,7 +55,7 @@ https://hazelcast.com/pricing/[hazelcast.com].
 
 === Release Notes
 
-Please refer to the http://docs.hazelcast.org/docs/release-notes/[Release Notes document] for the new features, enhancements and fixes performed for each Hazelcast IMDG release.
+Please refer to the https://docs.hazelcast.org/docs/release-notes/[Release Notes document] for the new features, enhancements and fixes performed for each Hazelcast IMDG release.
 
 
 [[contributing-to-hazelcast-imdg]]
@@ -108,7 +108,7 @@ The following information is sent in a phone home:
 
 **Phone Home Code**
 
-The phone home code itself is open source. Please see http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/util/PhoneHome.html[here].
+The phone home code itself is open source. Please see https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/util/PhoneHome.html[here].
 
 **Disabling Phone Homes**
 

--- a/src/docs/asciidoc/revision_history.adoc
+++ b/src/docs/asciidoc/revision_history.adoc
@@ -5,7 +5,7 @@
 
 This chapter lists the changes made to this document from the previous release.
 
-NOTE: Please refer to the http://docs.hazelcast.org/docs/rn/[Release Notes] for the new features, enhancements and fixes performed for each Hazelcast release.*
+NOTE: Please refer to the https://docs.hazelcast.org/docs/rn/[Release Notes] for the new features, enhancements and fixes performed for each Hazelcast release.*
 
 
 .Revision History

--- a/src/docs/asciidoc/rolling_member_upgrades.adoc
+++ b/src/docs/asciidoc/rolling_member_upgrades.adoc
@@ -58,7 +58,7 @@ The version in brackets `[3.9]` still denotes the member's codebase version (run
  At this point all members of the cluster have been upgraded to codebase version `3.9.0` but the cluster still operates at cluster version `3.8`. In order to use `3.9` features
  the cluster version must be changed to `3.9`. There are two ways to accomplish this:
  
-* Use http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#rolling-upgrade[Management Center].
+* Use https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#rolling-upgrade[Management Center].
 * Use the command line <<using-the-script-cluster-sh, cluster.sh script>>.
  
 NOTE: You need to upgrade your Management Center version *before* upgrading the member version if you want to 

--- a/src/docs/asciidoc/security.adoc
+++ b/src/docs/asciidoc/security.adoc
@@ -419,7 +419,7 @@ The property will provide a lot of logging output including the TLS/SSL handshak
 
 ==== TLS/SSL for Hazelcast Management Center
 
-In order to use secured communication between cluster and Management Center, you have to configure the cluster, see http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#connecting-hazelcast-members-to-management-center[Connecting Hazelcast members to Management Center].
+In order to use secured communication between cluster and Management Center, you have to configure the cluster, see https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#connecting-hazelcast-members-to-management-center[Connecting Hazelcast members to Management Center].
 
 
 === Integrating OpenSSL / BoringSSL

--- a/src/docs/asciidoc/serialization.adoc
+++ b/src/docs/asciidoc/serialization.adoc
@@ -438,7 +438,7 @@ You can declare Version in the configuration file `hazelcast.xml` using the `por
 </serialization>
 ----
 
-You can also use the interface http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/nio/serialization/VersionedPortable.html[VersionedPortable] which enables to upgrade the version per class, instead of global versioning. If you need to update only one class, you can use this interface. In this case, your class should implement `VersionedPortable` instead of `Portable`, and you can give the desired version using the method `VersionedPortable.getClassVersion()`.
+You can also use the interface https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/nio/serialization/VersionedPortable.html[VersionedPortable] which enables to upgrade the version per class, instead of global versioning. If you need to update only one class, you can use this interface. In this case, your class should implement `VersionedPortable` instead of `Portable`, and you can give the desired version using the method `VersionedPortable.getClassVersion()`.
 
 You should consider the following when you perform versioning.
 

--- a/src/docs/asciidoc/storage.adoc
+++ b/src/docs/asciidoc/storage.adoc
@@ -149,7 +149,7 @@ You can trigger the force start process using the Management Center, REST API an
 
 Please note that force start is a destructive process, which results in deletion of persisted Hot Restart data.
 
-Please refer to the http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#hot-restart[Hot Restart functionality] of the Management Center section to learn how you can perform a force start using the Management Center.
+Please refer to the https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#hot-restart[Hot Restart functionality] of the Management Center section to learn how you can perform a force start using the Management Center.
 
 ==== Partial Start
 
@@ -159,7 +159,7 @@ Partial start means that the cluster will start with an incomplete member set. D
 
 Partial start is controlled by `cluster-data-recovery-policy` configuration parameter and is not allowed by default. To enable partial start, one of the configuration values `PARTIAL_RECOVERY_MOST_RECENT` or `PARTIAL_RECOVERY_MOST_COMPLETE` should be set. Please see <<configuring-hot-restart, Configuring Hot Restart section>> for details.
 
-When partial start is enabled, Hazelcast can perform a partial start automatically or manually, in case of some members are unable to restart successfully. Partial start proceeds automatically when some members fail to start and join to the cluster in `validation-timeout-seconds`. After the `validation-timeout-seconds` duration is passed, Hot Restart chooses to perform partial start with the members present in the cluster. Moreover, partial start can be requested manually using the http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#hot-restart[Management Center], <<using-rest-api-for-cluster-management, REST API>> and <<example-usages-for-cluster-sh, cluster management scripts>> before the `validation-timeout-seconds` duration passes.
+When partial start is enabled, Hazelcast can perform a partial start automatically or manually, in case of some members are unable to restart successfully. Partial start proceeds automatically when some members fail to start and join to the cluster in `validation-timeout-seconds`. After the `validation-timeout-seconds` duration is passed, Hot Restart chooses to perform partial start with the members present in the cluster. Moreover, partial start can be requested manually using the https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#hot-restart[Management Center], <<using-rest-api-for-cluster-management, REST API>> and <<example-usages-for-cluster-sh, cluster management scripts>> before the `validation-timeout-seconds` duration passes.
 
 The other situation to decide to perform a partial start is failures during the data load phase. When Hazelcast learns data load result of all members which have passed the validation step, it automatically performs a partial start with the ones which have successfully restored their Hot Restart data. Please note that partial start does not expect every member to succeed in the data load step. It completes the process when it learns data load result for every member and there is at least one member which has successfully restored its Hot Restart data. Relatedly, if it cannot learn data load result of all members before `data-load-timeout-seconds` duration, it proceeds with the ones which have already completed the data load process.
 

--- a/src/docs/asciidoc/transactions.adoc
+++ b/src/docs/asciidoc/transactions.adoc
@@ -6,7 +6,7 @@ This chapter explains the usage of Hazelcast in a transactional context. It desc
 
 === Creating a Transaction Interface
 
-You create a `TransactionContext` object to begin, commit and rollback a transaction. You can obtain transaction-aware instances of queues, maps, sets, lists and multimaps via `TransactionContext`, work with them and commit/rollback in one shot. You can see the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/transaction/TransactionContext.html[TransactionContext API here].
+You create a `TransactionContext` object to begin, commit and rollback a transaction. You can obtain transaction-aware instances of queues, maps, sets, lists and multimaps via `TransactionContext`, work with them and commit/rollback in one shot. You can see the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/transaction/TransactionContext.html[TransactionContext API here].
 
 Hazelcast supports two types of transactions: ONE_PHASE and TWO_PHASE. The type of transaction controls what happens when a member crashes while a transaction is committing. The default behavior is TWO_PHASE.
 
@@ -51,7 +51,7 @@ NOTE: It should be noted that in split-brain situations or during a member failu
 
 XA describes the interface between the global transaction manager and the local resource manager. XA allows multiple resources (such as databases, application servers, message queues, transactional caches, etc.) to be accessed within the same transaction, thereby preserving the ACID properties across applications. XA uses a two-phase commit to ensure that all resources either commit or rollback any particular transaction consistently (all do the same).
 
-When you implement the `XAResource` interface, Hazelcast provides XA transactions. You can obtain the `HazelcastXAResource` instance via the `HazelcastInstance getXAResource` method. You can see the http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/transaction/HazelcastXAResource.html[HazelcastXAResource API here].
+When you implement the `XAResource` interface, Hazelcast provides XA transactions. You can obtain the `HazelcastXAResource` instance via the `HazelcastInstance getXAResource` method. You can see the https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/transaction/HazelcastXAResource.html[HazelcastXAResource API here].
 
 Below is example code that uses JTA API for transaction management.
 

--- a/src/docs/asciidoc/understanding_configuration.adoc
+++ b/src/docs/asciidoc/understanding_configuration.adoc
@@ -477,7 +477,7 @@ HazelcastInstance hz = Hazelcast.newHazelcastInstance(config);
 
 Variable replacers are used to replace custom strings during loading the configuration, e.g., they can be used to mask sensitive information such as usernames and passwords. Of course their usage is not limited to security related information.
 
-Variable replacers implement the interface `com.hazelcast.config.replacer.spi.ConfigReplacer` and they are configured only declaratively: in the Hazelcast's declarative configuration files, i.e., `hazelcast.xml` and `hazelcast-client.xml`. You can refer to `ConfigReplacer` s http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/config/replacer/spi/ConfigReplacer.html[Javadoc] for basic information on how a replacer works.
+Variable replacers implement the interface `com.hazelcast.config.replacer.spi.ConfigReplacer` and they are configured only declaratively: in the Hazelcast's declarative configuration files, i.e., `hazelcast.xml` and `hazelcast-client.xml`. You can refer to `ConfigReplacer` s https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/config/replacer/spi/ConfigReplacer.html[Javadoc] for basic information on how a replacer works.
 
 Variable replacers are configured within the element `<config-replacers>` under `<hazelcast>`, as shown below.
 

--- a/src/docs/asciidoc/understanding_configuration.adoc
+++ b/src/docs/asciidoc/understanding_configuration.adoc
@@ -2,7 +2,7 @@
 [[understanding-configuration]]
 == Understanding Configuration
 
-This chapter describes the options to configure your Hazelcast applications and explains the utilities which you can make use of while configuring. You can configure Hazelcast using one or mix of the following options: 
+This chapter describes the options to configure your Hazelcast applications and explains the utilities which you can make use of while configuring. You can configure Hazelcast using one or mix of the following options:
 
 * Declarative way
 * Programmatic way
@@ -187,7 +187,7 @@ Hazelcast.newHazelcastInstance( config );
 ----
 
 To retrieve an existing Hazelcast member by its name, use the following:
-    
+
 ```
 Hazelcast.getHazelcastInstanceByName( "my-instance" );
 ```
@@ -267,15 +267,15 @@ If you use Hazelcast with https://spring.io/[Spring] you can declare beans using
 </hz:hazelcast>
 ----
 
-Please see the <<spring-integration, Spring Integration section>> for more information on Hazelcast-Spring integration.
+Please see the <<integration-with-spring, Integration with Spring section>> for more information on Hazelcast-Spring integration.
 
 [[dynamically-adding-data-structure-configuration-on-a-cluster]]
 === Dynamically Adding Data Structure Configuration on a Cluster
 
-As described above, Hazelcast can be configured in a declarative or programmatic way; configuration must be completed before starting a Hazelcast member and this configuration cannot be altered at runtime, thus we refer to this as _static_ configuration. 
+As described above, Hazelcast can be configured in a declarative or programmatic way; configuration must be completed before starting a Hazelcast member and this configuration cannot be altered at runtime, thus we refer to this as _static_ configuration.
 
 Starting with Hazelcast 3.9, it is possible to dynamically add configuration for certain data structures at runtime; these can be added by invoking one of the `Config.add*Config` methods on the `Config` object obtained from a running member's `HazelcastInstance.getConfig()` method. For example:
- 
+
 [source,java]
 ----
 include::{javasource}/DynamicConfiguration.java[tag=dynconf]
@@ -294,7 +294,7 @@ Adding new dynamic configuration is supported for all `add*Config` methods excep
 
 [[handling-configuration-conflicts]]
 ==== Handling Configuration Conflicts
- 
+
 Attempting to add a dynamic configuration, when a static configuration for the same element already exists, will throw `ConfigurationException`. For example, assuming we start a member with the following fragment in `hazelcast.xml` configuration:
 
 ```
@@ -343,7 +343,7 @@ When you start a Hazelcast member without passing a `Config` object, as explaine
 ```
 -Dhazelcast.config=`*`<path to the hazelcast.xml>
 ```
-+	
++
 The path can be a regular one or a classpath reference with the prefix `classpath:`.
 * If the above system property is not set, Hazelcast then checks whether there is a `hazelcast.xml` file in the working directory.
 * If not, it then checks whether `hazelcast.xml` exists on the classpath.

--- a/src/docs/asciidoc/wan.adoc
+++ b/src/docs/asciidoc/wan.adoc
@@ -465,7 +465,7 @@ And, the following is the equivalent programmatic configuration:
 ...
 ----
 
-Note that you can clear a member's WAN replication event queue. It can be initiated through Management Center's http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#monitoring-wan-replication[Clear Queues action] or Hazelcast’s REST API. Below is the URL for its REST call:
+Note that you can clear a member's WAN replication event queue. It can be initiated through Management Center's https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#monitoring-wan-replication[Clear Queues action] or Hazelcast’s REST API. Below is the URL for its REST call:
 
 ```
 http://member_ip:port/hazelcast/rest/mancenter/wan/clearWanQueues
@@ -530,8 +530,8 @@ A WAN replication event is only eligible to publish if it passes all the filters
 Map and Cache have different filter interfaces: `MapWanEventFilter` and `CacheWanEventFilter`. Both of these interfaces have the method `filter` which takes the following parameters:
 
 - `mapName`/`cacheName`: Name of the related data structure.
-- `entryView`: http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/EntryView.html[EntryView]
-or http://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/cache/CacheEntryView.html[CacheEntryView] depending on the data structure.
+- `entryView`: https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/core/EntryView.html[EntryView]
+or https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/cache/CacheEntryView.html[CacheEntryView] depending on the data structure.
 - `eventType`: Enum type - `UPDATED(1)`, `REMOVED(2)` or `LOADED(3)` - depending on the event.
 
 NOTE: `LOADED` events are filtered out and not replicated to target cluster.
@@ -568,7 +568,7 @@ Starting with Hazelcast 3.7 you can initiate a synchronization operation on an I
 Synchronization operation sends all the data of an IMap to a target cluster to align the state of target IMap with source IMap.
 Synchronization is useful if two remote clusters lost their synchronization due to WAN queue overflow or in restart scenarios.
 
-Synchronization can be initiated through http://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#wan-sync[Management Center] and Hazelcast’s REST API. 
+Synchronization can be initiated through https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html#wan-sync[Management Center] and Hazelcast’s REST API. 
 
 Below is the URL for the REST call;
 


### PR DESCRIPTION
This PR contains 2 commits:
1. Uses `https` scheme in docs.hazelcast.org links
1. Fixes Spring integration anchor