### PR TITLE
Remove obsolete MC param

### DIFF
--- a/src/docs/asciidoc/system_properties.adoc
+++ b/src/docs/asciidoc/system_properties.adoc
@@ -396,11 +396,6 @@ NOTE: For detailed information on the diagnostic tool, along with this and the f
 | enum
 | Name of <<logging-configuration, logging>> framework type to send logging events.
 
-|`hazelcast.mancenter.home`
-| mancenter
-| string
-|  Folder where Management Center data files are stored (license information, time travel information, etc.).
-
 |`hazelcast.map.entry.filtering.natural.event.types`
 | false
 | bool


### PR DESCRIPTION
hazelcast.mancenter.home parameter has no effect for the members. It is
used by MC and documented on MC reference manual.