### PR TITLE
[BACKPORT 3.11.z] Fix OpenSSL Maven dependency snippet

### DIFF
--- a/src/docs/asciidoc/security.adoc
+++ b/src/docs/asciidoc/security.adoc
@@ -510,7 +510,7 @@ Example Maven dependencies (for Linux):
 <dependencies>
     <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty-tcnative-boringssl-static</artifactId>
+        <artifactId>netty-tcnative</artifactId>
         <version>2.0.12.Final</version>
         <classifier>linux-x86_64</classifier>
     </dependency>


### PR DESCRIPTION
Backport of #623 