### PR TITLE
Remove obsolete MC parameter

### DIFF
--- a/src/docs/asciidoc/system_properties.adoc
+++ b/src/docs/asciidoc/system_properties.adoc
@@ -483,13 +483,6 @@ CAUTION: Setting this value too low may cause members to be evicted from the clu
 | int
 | Maximum wait time before join operation.
 
-|`hazelcast.mc.max.visible.instance.count`
-| Integer.MAX_VALUE
-| int
-| Management Center maximum visible instance count. This property is deprecated as of this (3.10) release.
-
-CAUTION: Setting this value to a lower number might prevent some instances from being monitored in Management Center.
-
 |`hazelcast.mc.max.visible.slow.operations.count`
 |10
 |int


### PR DESCRIPTION
hazelcast.mc.max.visible.instance.count parameter was removed in 3.11.