### PR TITLE
[BACKPORT] Remove obsolete MC param

### DIFF
--- a/src/docs/asciidoc/system_properties.adoc
+++ b/src/docs/asciidoc/system_properties.adoc
@@ -9,9 +9,9 @@ NOTE: When you want to reconfigure a system property, you need to restart the me
 [cols="2,1,1,6"]
 .System Properties
 |===
-|Property Name 
-| Default Value 
-| Type 
+|Property Name
+| Default Value
+| Type
 | Description
 
 |`hazelcast.application.validation.token`
@@ -72,7 +72,7 @@ NOTE: When you want to reconfigure a system property, you need to restart the me
 |`hazelcast.diagnostics.directory`
 |`user.dir`
 |string
-|Output directory of the diagnostic log files. 
+|Output directory of the diagnostic log files.
 
 NOTE: For detailed information on the diagnostic tool, along with this and the following diagnostic related system properties, please refer to the <<diagnostics , Diagnostics section>>.
 
@@ -114,7 +114,7 @@ NOTE: For detailed information on the diagnostic tool, along with this and the f
 |`hazelcast.diagnostics.member-heartbeat.max-deviation-percentage`
 |100
 |int
-|Maximum allowed deviation for a member-to-member heartbeats.  
+|Maximum allowed deviation for a member-to-member heartbeats.
 
 |`hazelcast.diagnostics.memberinfo.period.second`
 |60
@@ -124,7 +124,7 @@ NOTE: For detailed information on the diagnostic tool, along with this and the f
 |`hazelcast.diagnostics.metric.level`
 |Mandatory
 |string
-|Level of detail for the diagnostic tool. 
+|Level of detail for the diagnostic tool.
 
 |`hazelcast.diagnostics.metrics.period.seconds`
 |60
@@ -134,7 +134,7 @@ NOTE: For detailed information on the diagnostic tool, along with this and the f
 |`hazelcast.diagnostics.metrics.level`
 |Mandatory
 |string
-|Level of detail for the Metrics plugin of the diagnostic tool. 
+|Level of detail for the Metrics plugin of the diagnostic tool.
 
 |`hazelcast.diagnostics.operation-heartbeat.seconds`
 |10
@@ -144,7 +144,7 @@ NOTE: For detailed information on the diagnostic tool, along with this and the f
 |`hazelcast.diagnostics.operation-heartbeat.max-deviation-percentage`
 |33
 |int
-|Maximum allowed deviation for a member-to-member operation heartbeats.  
+|Maximum allowed deviation for a member-to-member operation heartbeats.
 
 |`hazelcast.diagnostics.pending.invocations.period.seconds`
 |0
@@ -178,7 +178,7 @@ NOTE: For detailed information on the diagnostic tool, along with this and the f
 
 |`hazelcast.executionservice.taskscheduler.remove.oncancel`
 | false
-| bool 
+| bool
 | Controls whether the task scheduler removes tasks immediately upon cancellation. This is disabled by default, because it can cause severe delays on the other operations. By default all cancelled tasks will eventually get removed by the scheduler workers.
 
 |[[client-max-no]]`hazelcast.client.max.no.heartbeat.seconds`
@@ -191,49 +191,49 @@ NOTE: For detailed information on the diagnostic tool, along with this and the f
 |bool
 |When this property is true, if the server cannot determine the connected client version, it will assume that it has the version 3.6.x. This property is especially needed if you are using ICache (or JCache).
 
-|`hazelcast.connect.all.wait.seconds` 
-| 120 
-| int 
+|`hazelcast.connect.all.wait.seconds`
+| 120
+| int
 | Timeout to connect all other cluster members when a member is joining to a cluster.
 
-|`hazelcast.connection.monitor.interval` 
-| 100 
-| int 
+|`hazelcast.connection.monitor.interval`
+| 100
+| int
 | Minimum interval in milliseconds to consider a connection error as critical.
 
-|`hazelcast.connection.monitor.max.faults` 
-| 3 
-| int  
+|`hazelcast.connection.monitor.max.faults`
+| 3
+| int
 | Maximum IO error count before disconnecting from a member.
 
-|`hazelcast.discovery.public.ip.enabled` 
-| false 
-| bool 
+|`hazelcast.discovery.public.ip.enabled`
+| false
+| bool
 | Enable use of public IP address in member discovery with Discovery SPI. If you set this property to true in your source cluster, please make sure you have set the public addresses for your target members since they will be discovered using their public addresses. Otherwise, they cannot be discovered. Please see the <<public-address, Public Address section>>.
 
-|`hazelcast.enterprise.license.key` 
-| null 
-| string  
+|`hazelcast.enterprise.license.key`
+| null
+| string
 | http://www.hazelcast.com/products.jsp[Hazelcast IMDG Enterprise] license key.
 
-|`hazelcast.event.queue.capacity` 
-| 1000000 
-| int 
+|`hazelcast.event.queue.capacity`
+| 1000000
+| int
 | Capacity of internal event queue.
 
-|`hazelcast.event.queue.timeout.millis` 
-| 250 
-| int 
+|`hazelcast.event.queue.timeout.millis`
+| 250
+| int
 | Timeout to enqueue events to event queue.
 
-|`hazelcast.event.thread.count` 
-| 5 
-| int 
+|`hazelcast.event.thread.count`
+| 5
+| int
 | Number of event handler threads.
 
-|`hazelcast.graceful.shutdown.max.wait` 
-| 600 
-| int  
+|`hazelcast.graceful.shutdown.max.wait`
+| 600
+| int
 | Maximum wait in seconds during graceful shutdown.
 
 |`hazelcast.http.healthcheck.enabled`
@@ -261,9 +261,9 @@ NOTE: For detailed information on the diagnostic tool, along with this and the f
 |int
 |When the health monitoring level is *SILENT*, logs are printed only when the memory usage exceeds this threshold.
 
-|`hazelcast.heartbeat.interval.seconds` 
-| 5 
-| int  
+|`hazelcast.heartbeat.interval.seconds`
+| 5
+| int
 | Heartbeat send interval in seconds.
 
 |`hazelcast.hidensity.check.freememory`
@@ -272,53 +272,53 @@ NOTE: For detailed information on the diagnostic tool, along with this and the f
 |If enabled and is able to fetch memory statistics via Java's `OperatingSystemMXBean`, it checks whether there is enough free physical memory for the requested number of bytes. If the free memory checker is disabled (false), acts as if the check is succeeded.
 
 |`hazelcast.icmp.echo.fail.fast.on.startup`|
- true 
+ true
 | bool
 | Specifies whether ICMP Echo Request mode for ping detector is enforced. If OS is not supported, or not configured correctly, as explained in <<requirements-and-linuxunix-configuration, Requirements and Linux/Unix Configuration>>, Hazelcast will fail to start.
 
-|`hazelcast.icmp.enabled` 
-| false 
+|`hazelcast.icmp.enabled`
+| false
 | bool
 | Specifies whether ICMP ping is enabled or not.
 
-|`hazelcast.icmp.interval` 
-| 1000 
-| int 
+|`hazelcast.icmp.interval`
+| 1000
+| int
 | Interval between ping attempts in milliseconds. Default and minimum allowed value is 1 second.
 
 |[[max-attempts]]`hazelcast.icmp.max.attempts`
-| 3 
-| int 
+| 3
+| int
 | Maximum ping attempts before suspecting a member.
 
 |`hazelcast.icmp.parallel.mode`
-| true 
-| bool 
+| true
+| bool
 | Specifies whether <<ping-failure-detector, Ping Failure Detector>> will work in parallel with the other detectors.
 
-|`hazelcast.icmp.timeout` 
-| 1000 
-| int 
+|`hazelcast.icmp.timeout`
+| 1000
+| int
 | ICMP timeout in milliseconds. This cannot be more than the value of `hazelcast.icmp.interval` property; it should always be smaller.
 
-|`hazelcast.icmp.ttl` 
-| 0 
-| int 
+|`hazelcast.icmp.ttl`
+| 0
+| int
 | ICMP TTL (maximum numbers of hops to try).
 
-|`hazelcast.index.copy.behavior` 
-|COPY_ON_READ 
-| string 
+|`hazelcast.index.copy.behavior`
+|COPY_ON_READ
+| string
 | Defines the behavior for index copying on index read/write. Please refer to the <<copying-indexes, Copying Indexes section>>.
 
-|`hazelcast.initial.min.cluster.size` 
-| 0 
-| int  
+|`hazelcast.initial.min.cluster.size`
+| 0
+| int
 | Initial expected cluster size to wait before member to start completely.
 
-|`hazelcast.initial.wait.seconds` 
-| 0 
-| int  
+|`hazelcast.initial.wait.seconds`
+| 0
+| int
 | Initial time in seconds to wait before member to start completely.
 
 |`hazelcast.internal.map.expiration.cleanup.operation.count`
@@ -351,19 +351,19 @@ NOTE: For detailed information on the diagnostic tool, along with this and the f
 |int
 |Interval in seconds between IOBalancer executions.
 
-|`hazelcast.io.input.thread.count` 
-| 3 
-| int 
+|`hazelcast.io.input.thread.count`
+| 3
+| int
 | Number of socket input threads.
 
-|`hazelcast.io.output.thread.count` 
-| 3 
-| int 
+|`hazelcast.io.output.thread.count`
+| 3
+| int
 | Number of socket output threads.
 
-|`hazelcast.io.thread.count` 
-| 3 
-| int 
+|`hazelcast.io.thread.count`
+| 3
+| int
 | Number of threads performing socket input and socket output. If, for example, the default value (3) is used, it means there are 3 threads performing input and 3 threads performing output (6 threads in total).
 
 |`hazelcast.jcache.provider.type`
@@ -371,44 +371,44 @@ NOTE: For detailed information on the diagnostic tool, along with this and the f
 |string
 |Type of the JCache provider. Values can be `client` or `server`.
 
-|`hazelcast.jmx` 
-| false 
-| bool  
+|`hazelcast.jmx`
+| false
+| bool
 | Enable <<monitoring-with-jmx, JMX>> agent.
 
-|`hazelcast.legacy.memberlist.format.enabled`  
-| false  
-| bool  
+|`hazelcast.legacy.memberlist.format.enabled`
+| false
+| bool
 | Enables the legacy (for the releases before Hazelcast 3.9) member list format which is printed in the logs. The new format is introduced starting with Hazelcast 3.9 and includes member list version. Any change in the cluster, such as a member leaving or joining, will increment the member list version.<br>Please see the <<starting-the-member-and-client, Starting the Member and Client section>>.
 
 |`hazelcast.local.localAddress`
-| 
-| string 
+|
+| string
 | It is an overrider property for the default server socket listener's IP address. If this property is set, then this is the address where the server socket is bound to.
 
 |`hazelcast.local.publicAddress`
-| 
-| string 
+|
+| string
 | It is an overrider property for the default public address to be advertised to other cluster members and clients.
 
 |`hazelcast.lock.max.lease.time.seconds`
-|Long.MAX_VALUE 
-| long 
+|Long.MAX_VALUE
+| long
 | All locks which are acquired without an explicit lease time use this value (in seconds) as the lease time. When you want to set an explicit lease time for your locks, you cannot set it to a longer time than this value.
 
-|`hazelcast.logging.type` 
-| jdk 
-| enum 
+|`hazelcast.logging.type`
+| jdk
+| enum
 | Name of <<logging-configuration, logging>> framework type to send logging events.
 
-|`hazelcast.mancenter.home` 
-| mancenter 
-| string 
+|`hazelcast.mancenter.home`
+| mancenter
+| string
 |  Folder where Management Center data files are stored (license information, time travel information, etc.).
 
-|`hazelcast.map.entry.filtering.natural.event.types` 
-| false 
-| bool 
+|`hazelcast.map.entry.filtering.natural.event.types`
+| false
+| bool
 | Notify <<listening-to-map-entries-with-predicates, entry listeners with predicates>> on map entry updates with events that match entry, update or exit from predicate value space.
 
 |`hazelcast.map.expiry.delay.seconds`
@@ -416,24 +416,24 @@ NOTE: For detailed information on the diagnostic tool, along with this and the f
 |int
 |Useful to deal with some possible edge cases. For example, when using EntryProcessor, without this delay, you may see an EntryProcessor running on owner partition found a key but EntryBackupProcessor did not find it on backup. As a result of this, when backup promotes to owner, you will end up an unprocessed key.
 
-|`hazelcast.map.invalidation.batchfrequency.seconds` 
-| 10 
-| int 
+|`hazelcast.map.invalidation.batchfrequency.seconds`
+| 10
+| int
 |  If the collected invalidations do not reach the configured batch size, a background process sends them at this interval.
 
-|`hazelcast.map.invalidation.batch.enabled` 
-| true 
+|`hazelcast.map.invalidation.batch.enabled`
+| true
 | bool
 |  Enable or disable batching. When it is set to `false`, all invalidations are sent immediately.
 
 |`hazelcast.map.invalidation.batch.size`
-| 100 
-| int 
+| 100
+| int
 | Maximum number of invalidations in a batch.
 
-|`hazelcast.map.load.chunk.size` 
-| 1000 
-| int 
+|`hazelcast.map.load.chunk.size`
+| 1000
+| int
 | Maximum size of the key batch sent to the partition owners for value loading and the maximum size of a key batch for which values are loaded in a single partition.
 
 |`hazelcast.map.replica.wait.seconds.for.scheduled.tasks`
@@ -446,9 +446,9 @@ NOTE: For detailed information on the diagnostic tool, along with this and the f
 |string
 |Maximum write-behind queue capacity per member. It is the total of all write-behind queue sizes in a member including backups. Its maximum value is `Integer.MAX_VALUE`. The value of this property is taken into account only if the `write-coalescing` element of the Map Store configuration is `false`. Please refer to <<setting-write-behind-persistence, here>> for the description of the `write-coalescing` element.
 
-|`hazelcast.master.confirmation.interval.seconds` 
-| 30 
-| int  
+|`hazelcast.master.confirmation.interval.seconds`
+| 30
+| int
 | Interval at which members send master confirmation. This property is deprecated as of this (3.10) release.
 
 |`hazelcast.mastership.claim.member.list.version.increment`
@@ -456,9 +456,9 @@ NOTE: For detailed information on the diagnostic tool, along with this and the f
 |int
 | Hazelcast master member (oldewst in the cluster) increments the member list version for each joining member. Then, these member list versions are used to identify the joined members with unique integers. For this algorithm to work under network partitioning scenarios, without generating duplicate member list join versions for different members, a mastership-claiming member increments the member list version as specified by this parameter, multiplied by its position in the member list. The value of the parameter must be bigger than the cluster size.
 
-|`hazelcast.mastership.claim.timeout.seconds`  
-| 120  
-| int  
+|`hazelcast.mastership.claim.timeout.seconds`
+| 120
+| int
 | Timeout which defines when master candidate gives up waiting for response to its mastership claim. After timeout happens, non-responding member will be removed from the member list.
 
 |`hazelcast.max.join.merge.target.seconds`
@@ -471,58 +471,51 @@ NOTE: For detailed information on the diagnostic tool, along with this and the f
 |int
 | Join timeout, maximum time to try to join before giving.
 
-|`hazelcast.max.no.heartbeat.seconds` 
-| 60 
-| int  
+|`hazelcast.max.no.heartbeat.seconds`
+| 60
+| int
 | Maximum timeout of heartbeat in seconds for a member to assume it is dead.
 
 CAUTION: Setting this value too low may cause members to be evicted from the cluster when they are under heavy load: they will be unable to send heartbeat operations in time, so other members will assume that it is dead.
 
-|`hazelcast.max.no.master.confirmation.seconds` 
-| 150 
-| int  
+|`hazelcast.max.no.master.confirmation.seconds`
+| 150
+| int
 | Max timeout of master confirmation from other members. This property is deprecated as of this (3.10) release.
 
-|`hazelcast.max.wait.seconds.before.join` 
-| 20 
-| int  
+|`hazelcast.max.wait.seconds.before.join`
+| 20
+| int
 | Maximum wait time before join operation.
-
-|`hazelcast.mc.max.visible.instance.count` 
-| Integer.MAX_VALUE 
-| int  
-| Management Center maximum visible instance count. This property is deprecated as of this (3.10) release.
-
-CAUTION: Setting this value to a lower number might prevent some instances from being monitored in Management Center.
 
 |`hazelcast.mc.max.visible.slow.operations.count`
 |10
 |int
 |Management Center maximum visible slow operations count.
 
-|`hazelcast.mc.url.change.enabled` 
-| true 
-| bool  
+|`hazelcast.mc.url.change.enabled`
+| true
+| bool
 | Management Center changing server url is enabled.
 
-|`hazelcast.member.list.publish.interval.seconds` 
-| 60 
-| int  
+|`hazelcast.member.list.publish.interval.seconds`
+| 60
+| int
 | Interval at which master member publishes a member list.
 
 |`hazelcast.memcache.enabled`
-| false 
-| bool 
+| false
+| bool
 | Enable <<memcache-client, Memcache>> client request listener service.
 
-|`hazelcast.merge.first.run.delay.seconds` 
-| 300 
-| int 
+|`hazelcast.merge.first.run.delay.seconds`
+| 300
+| int
 | Initial run delay of <<split-brain-syndrome, split-brain/merge process>> in seconds.
 
-|`hazelcast.merge.next.run.delay.seconds` 
-| 120 
-| int 
+|`hazelcast.merge.next.run.delay.seconds`
+| 120
+| int
 | Run interval of <<split-brain-syndrome, split-brain/merge process>> in seconds.
 
 |`hazelcast.migration.min.delay.on.member.removed.seconds`
@@ -535,9 +528,9 @@ CAUTION: Setting this value to a lower number might prevent some instances from 
 |string
 |IP address of a multicast group. If not set, configuration is read from the default Hazelcast configuration, which has the value 224.2.2.3.
 
-|`hazelcast.nio.tcp.spoofing.checks` 
-| false 
-| bool 
+|`hazelcast.nio.tcp.spoofing.checks`
+| false
+| bool
 | Controls whether more strict checks upon BIND requests towards a cluster member are applied. The checks mainly validate the remote BIND request against the remote address as found in the socket. By default they are disabled, to avoid connectivity issues when deployed under NAT'ed infrastructure.
 
 |`hazelcast.operation.backup.timeout.millis`
@@ -546,18 +539,18 @@ CAUTION: Setting this value to a lower number might prevent some instances from 
 |Maximum time a caller to wait for backup responses of an operation. After this timeout, operation response will be returned to the caller even no backup response is received.
 
 |`hazelcast.operation.fail.on.indeterminate.state`
-| false 
-| bool 
+| false
+| bool
 | When enabled, an operation fails with `IndeterminateOperationStateException`, if it does not receive backup acks in time with respect to backup configuration of its data structure, or the member which owns primary replica of the target partition leaves the cluster.
 
 |`hazelcast.operation.call.timeout.millis`
-| 60000 
-| int 
+| 60000
+| int
 | Timeout to wait for a response when a remote call is sent, in milliseconds.
 
-|`hazelcast.operation.generic.thread.count` 
-| -1 
-| int 
+|`hazelcast.operation.generic.thread.count`
+| -1
+| int
 | Number of generic operation handler threads. `-1` means CPU core count / 2.
 
 |`hazelcast.operation.responsequeue.idlestrategy`
@@ -565,9 +558,9 @@ CAUTION: Setting this value to a lower number might prevent some instances from 
 |string
 |Specifies whether the response thread for internal operations at the member side will be blocked or not. If you use `block` (the default value) the thread will be blocked and need to be notified which can cause a reduction in the performance. If you use `backoff` there will be no blocking. By enabling the backoff mode and depending on your use case, you can get a 5-10% performance improvement. However, keep in mind that this will increase CPU utilization. We recommend you to use backoff with care and if you have a tool for measuring your cluster's performance.
 
-|`hazelcast.operation.thread.count` 
-| -1 
-| int 
+|`hazelcast.operation.thread.count`
+| -1
+| int
 | Number of partition based operation handler threads. `-1` means CPU core count.
 
 |`hazelcast.partition.backup.sync.interval`
@@ -575,9 +568,9 @@ CAUTION: Setting this value to a lower number might prevent some instances from 
 |int
 |Interval for syncing backup replicas in seconds.
 
-|`hazelcast.partition.count` 
-| 271 
-| int  
+|`hazelcast.partition.count`
+| 271
+| int
 | Total partition count.
 
 |`hazelcast.partition.max.parallel.replications`
@@ -585,24 +578,24 @@ CAUTION: Setting this value to a lower number might prevent some instances from 
 |int
 |Maximum number of parallel partition backup replication operations per member. When a partition backup ownership changes or a backup inconsistency is detected, the members start to sync their backup partitions. This parameter limits the maximum running replication operations in parallel.
 
-|`hazelcast.partition.migration.fragments.enabled` 
-| true 
-| bool 
+|`hazelcast.partition.migration.fragments.enabled`
+| true
+| bool
 | When enabled, which is the default behavior, partitions are migrated/replicated in small fragments instead of one big chunk. Migrating partitions in fragments reduces pressure on the memory and network, since smaller packets are created in the memory and sent through the network. Note that it can increase the migration time to complete.
 
-|`hazelcast.partition.migration.interval` 
-| 0 
-| int 
+|`hazelcast.partition.migration.interval`
+| 0
+| int
 | Interval to run partition migration tasks in seconds.
 
-|`hazelcast.partition.migration.stale.read.disabled` 
-| false 
-| bool 
+|`hazelcast.partition.migration.stale.read.disabled`
+| false
+| bool
 | Hazelcast allows read operations to be performed while a partition is being migrated. This can lead to stale reads for some scenarios. You can disable stale read operations by setting this system property's value to "true". Its default value is "false", meaning that stale reads are allowed.
 
-|`hazelcast.partition.migration.timeout` 
-| 300 
-| int  
+|`hazelcast.partition.migration.timeout`
+| 300
+| int
 | Timeout for partition migration tasks in seconds.
 
 |`hazelcast.partition.table.send.interval`
@@ -635,9 +628,9 @@ CAUTION: Setting this value to a lower number might prevent some instances from 
 |int
 | The period between successive entries in the performance monitor's log file.
 
-|`hazelcast.prefer.ipv4.stack` 
-| true 
-| bool  
+|`hazelcast.prefer.ipv4.stack`
+| true
+| bool
 | Prefer IPv4 network interface when picking a local address.
 
 |`hazelcast.query.max.local.partition.limit.for.precheck`
@@ -660,9 +653,9 @@ CAUTION: Setting this value to a lower number might prevent some instances from 
 |int
 |Result size limit for query operations on maps. This value defines the maximum number of returned elements for a single query result. If a query exceeds this number of elements, a QueryResultSizeExceededException is thrown. Its default value is -1, meaning it is disabled.
 
-|`hazelcast.rest.enabled` 
-| false 
-| bool 
+|`hazelcast.rest.enabled`
+| false
+| bool
 | Enable <<rest-client, REST>> client request listener service.
 
 |[[permission-onjoin]]`hazelcast.security.permission.update.onjoin.disable`
@@ -670,9 +663,9 @@ CAUTION: Setting this value to a lower number might prevent some instances from 
 |bool
 |It is used to specify whether a new member joining to a cluster will apply the <<permissions, client permissions>> stored in its own configuration, or use the ones configured in the cluster. Its default value is false, i.e., the joining member uses the client permissions defined in the cluster.
 
-|`hazelcast.shutdownhook.enabled` 
-| true 
-| bool  
+|`hazelcast.shutdownhook.enabled`
+| true
+| bool
 | Enable Hazelcast shutdownhook thread. When this is enabled, this thread terminates the Hazelcast instance without waiting to shutdown gracefully.
 
 |`hazelcast.shutdownhook.policy`
@@ -705,9 +698,9 @@ CAUTION: Setting this value to a lower number might prevent some instances from 
 |int
 |Defines a threshold above which a running operation in `OperationService` is considered to be slow. These operations log a warning and are shown in the Management Center with detailed information, e.g., stacktrace.
 
-|`hazelcast.socket.bind.any` 
-| true 
-| bool 
+|`hazelcast.socket.bind.any`
+| true
+| bool
 | Bind both server-socket and client-sockets to any local interface.
 
 |`hazelcast.socket.buffer.direct`
@@ -720,9 +713,9 @@ CAUTION: Setting this value to a lower number might prevent some instances from 
 |bool
 |Bind client socket to an interface when connecting to a remote server socket. When set to `false`, client socket is not bound to any interface.
 
-|`hazelcast.socket.client.bind.any` 
-| true 
-| bool 
+|`hazelcast.socket.client.bind.any`
+| true
+| bool
 | Bind client-sockets to any local interface. If not set, `hazelcast.socket.bind.any` will be used as default.
 
 |`hazelcast.socket.client.receive.buffer.size`
@@ -740,9 +733,9 @@ CAUTION: Setting this value to a lower number might prevent some instances from 
 |int
 |Socket connection timeout in seconds. `Socket.connect()` will be blocked until either connection is established or connection is refused or this timeout passes. Default is 0, means infinite.
 
-|`hazelcast.socket.keep.alive` 
-| true 
-| bool 
+|`hazelcast.socket.keep.alive`
+| true
+| bool
 | Socket set keep alive (`SO_KEEPALIVE`).
 
 |`hazelcast.socket.linger.seconds`
@@ -750,24 +743,24 @@ CAUTION: Setting this value to a lower number might prevent some instances from 
 |int
 |Set socket `SO_LINGER` option.
 
-|`hazelcast.socket.no.delay` 
-| true 
-| bool  
+|`hazelcast.socket.no.delay`
+| true
+| bool
 | Socket set TCP no delay.
 
-|`hazelcast.socket.receive.buffer.size` 
-| 128 
-| int 
-| Socket receive buffer (`SO_RCVBUF`) size in KB. If you have a very fast network, e.g., 10gbit) and/or you have large entries, then you may benefit from increasing sender/receiver buffer sizes. Use this property and the next one below tune the size. 
+|`hazelcast.socket.receive.buffer.size`
+| 128
+| int
+| Socket receive buffer (`SO_RCVBUF`) size in KB. If you have a very fast network, e.g., 10gbit) and/or you have large entries, then you may benefit from increasing sender/receiver buffer sizes. Use this property and the next one below tune the size.
 
-|`hazelcast.socket.send.buffer.size` 
-| 128 
-| int  
+|`hazelcast.socket.send.buffer.size`
+| 128
+| int
 | Socket send buffer (`SO_SNDBUF`) size in KB.
 
-|`hazelcast.socket.server.bind.any` 
-| true 
-| bool 
+|`hazelcast.socket.server.bind.any`
+| true
+| bool
 | Bind server-socket to any local interface. If not set, `hazelcast.socket.bind.any` will be used as default.
 
 |`hazelcast.tcp.join.port.try.count`
@@ -775,23 +768,23 @@ CAUTION: Setting this value to a lower number might prevent some instances from 
 |int
 |The number of incremental ports, starting with the port number defined in the network configuration, that will be used to connect to a host (which is defined without a port in TCP/IP member list while a member is searching for a cluster).
 
-|`hazelcast.unsafe.mode` 
-| auto 
-| string  
+|`hazelcast.unsafe.mode`
+| auto
+| string
 | "auto" (the default value) automatically detects whether the usage of `Unsafe` is suitable for a given platform. "disabled" explicitly disables the `Unsafe` usage in your platform. "enforced" enforces the usage of `Unsafe` even if your platform does not support it. This property can only be set by passing a JVM-wide system property.
 
-|`hazelcast.phone.home.enabled` 
-| true 
-| bool  
+|`hazelcast.phone.home.enabled`
+| true
+| bool
 | Enable or disable the sending of phone home data to Hazelcast's phone home server.
 
-|`hazelcast.wait.seconds.before.join` 
-| 5 
-| int  
+|`hazelcast.wait.seconds.before.join`
+| 5
+| int
 | Wait time before join operation.
 
-|`hazelcast.wan.map.useDeleteWhenProcessingRemoveEvents` 
-| false 
-| bool  
+|`hazelcast.wan.map.useDeleteWhenProcessingRemoveEvents`
+| false
+| bool
 | Configures WAN replication for `IMap` on the PASSIVE cluster to remove entries using delete instead of remove and when using `com.hazelcast.enterprise.wan.replication.WanBatchReplication` as an endpoint implementation. The member which receives the event batch in the PASSIVE cluster dispatches WAN events to the partition owners as map merge and remove operations. When using remove operations, the old entry value is sent from the partition owner to the caller even though the caller does not use the old value. This can also lead to issues if the PASSIVE cluster does not contain the class definition for the entry value as the value will try to get deserialized, causing `ClassNotFoundException`s. You can switch to using map remove instead on the PASSIVE cluster with this property. This will both save bandwidth and avoid the exception.
 |===


### PR DESCRIPTION
hazelcast.mc.max.visible.instance.count parameter was removed in 3.11.