### PR TITLE
Update default value in CPSubsystemConfig

### DIFF
--- a/src/docs/asciidoc/cp_subsystem.adoc
+++ b/src/docs/asciidoc/cp_subsystem.adoc
@@ -57,29 +57,29 @@ All of the API methods in the new `FencedLock` abstraction offer the exactly-onc
 
 ==== CPSubsystem Configuration
 
-- `cpMemberCount`: Number of `CPMember` s to initialize the `CPSubsystem`. It is `0` by default and the CP subsystem is disabled. The CP subsystem is enabled when a positive value is set. After the CP subsystem is initialized successfully, more CP members can be added at run-time and number of active CP members can go beyond the configured CP member count. Number of CP members can be smaller than total size of the Hazelcast cluster. For instance, one can run 5 CP members in a 20-member Hazelcast cluster.
+- `cp-member-count`: Number of `CPMember` s to initialize the `CPSubsystem`. It is `0` by default and the CP subsystem is disabled. The CP subsystem is enabled when a positive value is set. After the CP subsystem is initialized successfully, more CP members can be added at run-time and number of active CP members can go beyond the configured CP member count. Number of CP members can be smaller than total size of the Hazelcast cluster. For instance, one can run 5 CP members in a 20-member Hazelcast cluster.
 +
-If set, must be greater than or equal to `groupSize`.
+If set, must be greater than or equal to `group-size`.
 
-- `groupSize`: Number of CP members for running CP groups. If set, it must be an odd number between `3` and `7`. Otherwise, `cpMemberCount` is respected.
+- `group-size`: Number of CP members for running CP groups. If set, it must be an odd number between `3` and `7`. Otherwise, `cp-member-count` is respected.
 +
-If set, must be smaller than or equal to `cpMemberCount`.
+If set, must be smaller than or equal to `cp-member-count`.
 
-- `sessionTimeToLiveSeconds`: Duration for a CP session to be kept alive after the last heartbeat it has received. The session will be closed if there is no new heartbeat during this duration. Session TTL must be decided wisely. If a very low value is set, CP session of a Hazelcast instance can be closed prematurely if the instance temporarily loses connectivity to the CP subsystem because of a network partition or a GC pause. In such an occasion, all CP resources of this Hazelcast instance, such as `FencedLock` or `ISemaphore`, are released. On the other hand, if a very large value is set, CP resources can remain assigned to an actually crashed Hazelcast instance for too long and liveliness problems can occur. The CP subsystem offers an API `CPSessionManagementService`, to deal with liveliness issues related to CP sessions. In order to prevent premature session expires, session TTL configuration can be set a relatively large value and `CPSessionManagementService.forceCloseSession(String, long)` can be manually called to close CP session of a crashed Hazelcast instance.
+- `session-time-to-live-seconds`: Duration for a CP session to be kept alive after the last heartbeat it has received. The session will be closed if there is no new heartbeat during this duration. Session TTL must be decided wisely. If a very low value is set, CP session of a Hazelcast instance can be closed prematurely if the instance temporarily loses connectivity to the CP subsystem because of a network partition or a GC pause. In such an occasion, all CP resources of this Hazelcast instance, such as `FencedLock` or `ISemaphore`, are released. On the other hand, if a very large value is set, CP resources can remain assigned to an actually crashed Hazelcast instance for too long and liveliness problems can occur. The CP subsystem offers an API `CPSessionManagementService`, to deal with liveliness issues related to CP sessions. In order to prevent premature session expires, session TTL configuration can be set a relatively large value and `CPSessionManagementService.forceCloseSession(String, long)` can be manually called to close CP session of a crashed Hazelcast instance.
 +
-Must be greater than `sessionHeartbeatIntervalSeconds`, and smaller than or equal to `missingCPMemberAutoRemovalSeconds`. Default value is `300` seconds.
+Must be greater than `session-heartbeat-interval-seconds`, and smaller than or equal to `missing-cp-member-auto-removal-seconds`. Default value is `300` seconds.
 
-- `sessionHeartbeatIntervalSeconds`: Interval for the periodically-committed CP session heartbeats. A CP session is started on a CP group with the first session-based request of a Hazelcast instance. After that moment, heartbeats are periodically committed to the CP group.
+- `session-heartbeat-interval-seconds`: Interval for the periodically-committed CP session heartbeats. A CP session is started on a CP group with the first session-based request of a Hazelcast instance. After that moment, heartbeats are periodically committed to the CP group.
 +
 Must be smaller than `sessionTimeToLiveSeconds`. Default value is `5` seconds.
 
-- `missingCPMemberAutoRemovalSeconds`: Duration to wait before automatically removing a missing CP member from the CP subsystem. It is `0` by default and disabled. When a CP member leaves the cluster, it is not automatically removed from the CP subsystem, since the missing CP member could be still alive and left the cluster because of a network partition. On the other hand, if a missing CP member is actually crashed, it creates a danger for its CP groups, because it will be still part of majority calculations. This situation could lead to losing majority of CP groups if multiple CP members leave the cluster over time.
+- `missing-cp-member-auto-removal-seconds`: Duration to wait before automatically removing a missing CP member from the CP subsystem. When a CP member leaves the cluster, it is not automatically removed from the CP subsystem, since it could be still alive and left the cluster because of a network partition. On the other hand, if a missing CP member is actually crashed, it creates a danger for its CP groups, because it will be still part of majority calculations. This situation could lead to losing majority of CP groups if multiple CP members leave the cluster over time.
 +
-If this configuration is enabled, missing CP members will be automatically removed from the CP subsystem after some time. This feature is very useful in terms of fault tolerance when CP member count is also configured to be larger than group size. In this case, a missing CP member will be safely replaced in its CP groups with other available CP members in the CP subsystem. This configuration also implies that no network partition is expected to be longer than the configured duration.
+With the default configuration, missing CP members will be automatically removed from the CP subsystem after `4` hours. This feature is very useful in terms of fault tolerance when CP member count is also configured to be larger than group size. In this case, a missing CP member will be safely replaced in its CP groups with other available CP membersin the CP subsystem. This configuration also implies that no network partition is expected to be longer than the configured duration.
 +
-Must be greater than or equal to `sessionTimeToLiveSeconds`. Default value is `0`.
+Must be greater than or equal to `session-time-to-live-seconds`. Default value is `4` hours.
 
-- `failOnIndeterminateOperationState`: Offers a choice between at-least-once and at-most-once execution of the operations on top of the Raft consensus algorithm. It is disabled by default and offers at-least-once execution guarantee. If enabled, it switches to at-most-once execution guarantee. When you invoke an API method on a CP data structure proxy, it replicates an internal operation to the corresponding CP group. After this operation is committed to majority of this CP group by the Raft leader node, it sends a response for the public API call. If a failure causes loss of the response, then the calling side cannot determine if the operation is committed on the CP group or not. In this case, if this configuration is disabled, the operation is replicated again to the CP group, and hence could be committed multiple times. If it is enabled, the public API call fails with `IndeterminateOperationStateException`.
+- `fail-on-indeterminate-operation-state`: Offers a choice between at-least-once and at-most-once execution of the operations on top of the Raft consensus algorithm. It is disabled by default and offers at-least-once execution guarantee. If enabled, it switches to at-most-once execution guarantee. When you invoke an API method on a CP data structure proxy, it replicates an internal operation to the corresponding CP group. After this operation is committed to majority of this CP group by the Raft leader node, it sends a response for the public API call. If a failure causes loss of the response, then the calling side cannot determine if the operation is committed on the CP group or not. In this case, if this configuration is disabled, the operation is replicated again to the CP group, and hence could be committed multiple times. If it is enabled, the public API call fails with `IndeterminateOperationStateException`.
 +
 Default value is `false`.
 
@@ -94,7 +94,7 @@ Default value is `false`.
         <group-size>3</group-size>
         <session-time-to-live-seconds>300</session-time-to-live-seconds>
         <session-heartbeat-interval-seconds>5</session-heartbeat-interval-seconds>
-        <missing-cp-member-auto-removal-seconds>0</missing-cp-member-auto-removal-seconds>
+        <missing-cp-member-auto-removal-seconds>14400</missing-cp-member-auto-removal-seconds>
         <fail-on-indeterminate-operation-state>false</fail-on-indeterminate-operation-state>
     </cp-subsystem>
     ...
@@ -111,11 +111,11 @@ include::{javasource}/cp/CpSubsystemConfiguration.java[tag=cpconf]
 ==== FencedLock Configuration
 
 - `name`: Name of the FencedLock
-- `lockAcquireLimit`: Maximum number of reentrant lock acquires. Once a caller acquires the lock this many times, it will not be able to acquire the lock again, until it makes at least one `unlock()` call.
+- `lock-acquire-limit`: Maximum number of reentrant lock acquires. Once a caller acquires the lock this many times, it will not be able to acquire the lock again, until it makes at least one `unlock()` call.
 +
-By default, no upper bound is set for the number of reentrant lock acquires, which means that once a caller acquires a `FencedLock`, all of its further `lock()` calls will succeed. However, for instance, if you set `lockAcquireLimit` to `2`, once a caller acquires the lock, it will be able to acquire it once more, but its third `lock()` call will not succeed.
+By default, no upper bound is set for the number of reentrant lock acquires, which means that once a caller acquires a `FencedLock`, all of its further `lock()` calls will succeed. However, for instance, if you set `lock-acquire-limit` to `2`, once a caller acquires the lock, it will be able to acquire it once more, but its third `lock()` call will not succeed.
 +
-If `lockAcquireLimit` is set to 1, then the lock becomes non-reentrant.
+If `lock-acquire-limit` is set to 1, then the lock becomes non-reentrant.
 +
 `0` means there is no upper bound for number of reentrant lock acquires. Default value is `0`.
 
@@ -156,7 +156,7 @@ include::{javasource}/cp/CpSubsystemConfiguration.java[tag=cplockconf]
 ==== Semaphore Configuration
 
 - `name`: Name of the CP semaphore
-- `jdkCompatible`: Enables / disables JDK compatibility of the CP `ISemaphore`. When it is JDK compatible, just as in the `j.u.c.Semaphore.release()` method, a permit can be released without acquiring it first, because acquired permits are not bound to threads. However, there is no auto-cleanup of acquired permits upon Hazelcast server/client failures. If a permit holder fails, its permits must be released manually. When JDK compatibility is disabled, a `HazelcastInstance` must acquire permits before releasing them and it cannot release a permit that it has not acquired. It means, you can acquire a permit from one thread and release it from another thread using the same `HazelcastInstance`, but not different instances of `HazelcastInstance`. In this mode, acquired permits are automatically released upon failure of the holder `HazelcastInstance`. So there is a minor behavioral difference to the `j.u.c.Semaphore.release()` method.
+- `jdk-compatible`: Enables / disables JDK compatibility of the CP `ISemaphore`. When it is JDK compatible, just as in the `j.u.c.Semaphore.release()` method, a permit can be released without acquiring it first, because acquired permits are not bound to threads. However, there is no auto-cleanup of acquired permits upon Hazelcast server/client failures. If a permit holder fails, its permits must be released manually. When JDK compatibility is disabled, a `HazelcastInstance` must acquire permits before releasing them and it cannot release a permit that it has not acquired. It means, you can acquire a permit from one thread and release it from another thread using the same `HazelcastInstance`, but not different instances of `HazelcastInstance`. In this mode, acquired permits are automatically released upon failure of the holder `HazelcastInstance`. So there is a minor behavioral difference to the `j.u.c.Semaphore.release()` method.
 +
 JDK compatibility is disabled by default.
 
@@ -194,13 +194,13 @@ include::{javasource}/cp/CpSubsystemConfiguration.java[tag=cpsemaconf]
 
 WARNING: These parameters are to tune specific parameters of Hazelcast's Raft consensus algorithm implementation and only for power users.
 
-- `leaderElectionTimeoutInMillis`: Leader election timeout in milliseconds. If a candidate cannot win majority of the votes in time, a new election round is initiated. Default value is `2000`.
-- `leaderHeartbeatPeriodInMillis`: Period for leader to send heartbeat messages to its followers. Default value is `5000`.
-- `maxMissedLeaderHeartbeatCount`: Max number of missed leader heartbeats to trigger a new leader election. Default value is `5`.
-- `appendRequestMaxEntryCount`: Max entry count that can be sent in a single batch of append entries request. Default value is `50`.
-- `commitIndexAdvanceCountToSnapshot`: Number of commits to initiate a new snapshot after the last snapshot's index. Default value is `1000`.
-- `uncommittedEntryCountToRejectNewAppends`: Max number of uncommitted entries in the leader's Raft log before temporarily rejecting new requests of callers. Default value is `100`.
-- `appendRequestBackoffTimeoutInMillis`: Timeout for append request backoff in millis. After the leader sends an append request to a follower, it will not send a subsequent append request until the responds to the former request or this timeout occurs. Default value is `100`.
+- `leader-election-timeout-in-millis`: Leader election timeout in milliseconds. If a candidate cannot win majority of the votes in time, a new election round is initiated. Default value is `2000`.
+- `leader-heartbeat-period-in-millis`: Period for leader to send heartbeat messages to its followers. Default value is `5000`.
+- `max-missed-leader-heartbeat-count`: Max number of missed leader heartbeats to trigger a new leader election. Default value is `5`.
+- `append-request-max-entry-count`: Max entry count that can be sent in a single batch of append entries request. Default value is `50`.
+- `commit-index-advance-count-to-snapshot`: Number of commits to initiate a new snapshot after the last snapshot's index. Default value is `1000`.
+- `uncommitted-entry-count-to-reject-new-appends`: Max number of uncommitted entries in the leader's Raft log before temporarily rejecting new requests of callers. Default value is `100`.
+- `append-request-backoff-timeout-in-millis`: Timeout for append request backoff in millis. After the leader sends an append request to a follower, it will not send a subsequent append request until the responds to the former request or this timeout occurs. Default value is `100`.
 
 **Declarative Configuration**:
 

--- a/src/main/java/cp/CpSubsystemConfiguration.java
+++ b/src/main/java/cp/CpSubsystemConfiguration.java
@@ -12,7 +12,7 @@ public class CpSubsystemConfiguration {
               .setGroupSize(3)
               .setSessionTimeToLiveSeconds(300)
               .setSessionHeartbeatIntervalSeconds(5)
-              .setMissingCPMemberAutoRemovalSeconds(0)
+              .setMissingCPMemberAutoRemovalSeconds(14400)
               .setFailOnIndeterminateOperationState(false);
         //end::cpconf[]
 


### PR DESCRIPTION
`missingCPMemberAutoRemovalSeconds` is set to 4 hours by default.

see https://github.com/hazelcast/hazelcast/pull/14531