### PR TITLE
Updates JVM compatibility table (min Java 8 requirement since 3.12)

### DIFF
--- a/src/docs/asciidoc/distributed_query.adoc
+++ b/src/docs/asciidoc/distributed_query.adoc
@@ -1634,59 +1634,6 @@ underlying MapReduce framework by supplying a custom configured
 configure the MapReduce framework, please see <<configuring-jobtracker, Configuring JobTracker>>. We will
 later see another way to configure the automatically used MapReduce framework if no special `JobTracker` is supplied.
 
-===== Aggregations and Java
-
-To make Aggregations more convenient to use and future proof, the API is heavily optimized for Java 8 and future versions.
-The API is still fully compatible with any Java version Hazelcast supports (Java 6 and Java 7). The biggest difference is how you
-work with the Java generics: on Java 6 and 7, the process to resolve generics is not as strong as on Java 8 and
-future Java versions. In addition, the whole Aggregations API has full Java 8 Project Lambda (or Closure,
-https://jcp.org/en/jsr/detail?id=335[JSR 335]) support.
-
-For illustration of the differences in Java 6 and 7 in comparison to Java 8, we will have a quick look at code
-examples for both. After that, we will focus on using Java 8 syntax to keep examples short and easy to understand. We will see some hints about what the code looks like in Java 6 or 7.
-
-The first example produces the sum of some `int` values stored in a Hazelcast IMap. This example does not use much of the functionality of the Aggregations framework, but it shows the main difference.
-
-[source,java]
-----
-IMap<String, Integer> personAgeMapping = hazelcastInstance.getMap( "person-age" );
-for ( int i = 0; i < 1000; i++ ) {
-    String lastName = RandomUtil.randomLastName();
-    int age = RandomUtil.randomAgeBetween( 20, 80 );
-    personAgeMapping.put( lastName, Integer.valueOf( age ) );
-}
-----
-
-With our demo data prepared, we can see how to produce the sums in different Java versions.
-
-===== Aggregations and Java 6 or Java 7
-
-Since Java 6 and 7 are not as strong on resolving generics as Java 8, you need to be a bit more verbose
-with the code you write. You might also consider using raw types but breaking the type safety to ease this process.
-
-For a short introduction on what the following code example means, look at the source code comments. We will later dig deeper into
-the different options.
-
-[source,java]
-----
-// No filter applied, select all entries
-Supplier<String, Integer, Integer> supplier = Supplier.all();
-// Choose the sum aggregation
-Aggregation<String, Integer, Integer> aggregation = Aggregations.integerSum();
-// Execute the aggregation
-int sum = personAgeMapping.aggregate( supplier, aggregation );
-----
-
-===== Aggregations and Java 8
-
-With Java 8, the Aggregations API looks simpler because Java 8 can resolve the generic parameters for us. That means
-the above lines of Java 6/7 example code ends up in just one easy line on Java 8.
-
-[source,java]
-----
-int sum = personAgeMapping.aggregate( Supplier.all(), Aggregations.integerSum() );
-----
-
 ===== Aggregations and the MapReduce Framework
 
 As mentioned before, the Aggregations implementation is based on the Hazelcast MapReduce framework and therefore you might find

--- a/src/docs/asciidoc/getting_started.adoc
+++ b/src/docs/asciidoc/getting_started.adoc
@@ -241,16 +241,18 @@ Following table summarizes the version compatibility between Hazelcast IMDG and 
 
 |Hazelcast IMDG Version | JDK Version | Oracle JDK | IBM SDK, Java Technology Edition | Azul Zing JDK | Azul Zulu OpenJDK
 
-| Up to 4.0
+| Up to 3.11
 
-(_JDK 6 support will be dropped with the release of Hazelcast IMDG 4.0_)
+(_JDK 6 support is dropped with the release of Hazelcast IMDG 3.12_)
 | 6
 | icon:check[]
 | icon:times[]
 | icon:check[]
 | icon:check[]
 
-| Up to current
+| Up to 3.11
+
+(_JDK 7 support is dropped with the release of Hazelcast IMDG 3.12_)
 | 7
 | icon:check[]
 | icon:check[]

--- a/src/docs/asciidoc/security.adoc
+++ b/src/docs/asciidoc/security.adoc
@@ -557,7 +557,7 @@ Other supported properties are:
 ** `SSLv2` _(insecure!)_
 ** `SSLv3` _(insecure!)_
 +
-All of the algorithms listed above support Java 6 and higher versions. For the `protocol` property, we recommend you to provide SSL or TLS with its version information, e.g., `TLSv1.2`. Note that if you
+All of the algorithms listed above support Java 8 and higher versions. For the `protocol` property, we recommend you to provide SSL or TLS with its version information, e.g., `TLSv1.2`. Note that if you
 provide only `SSL` or `TLS` as a value for the `protocol` property, they are converted to `SSLv3` and `TLSv1.2`, respectively. We strongly recommend to avoid SSL protocols.
 
 ==== Configuring Cipher Suites


### PR DESCRIPTION
Also removes a section on Java 6/7 vs 8 in Aggregations documentation
since this is no longer relevant.