### PR TITLE
Updates for JCache 1.1.1 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ repositories {
      compile "com.hazelcast:hazelcast-client:$imdgVersion"
      compile "com.atomikos:transactions-jta:4.0.6"
      compile "javax.transaction:javax.transaction-api:1.3"
-     compile "javax.cache:cache-api:1.1.0"
+     compile "javax.cache:cache-api:1.1.1"
      compile "org.mongodb:mongo-java-driver:3.0.4"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'java'
 
 
 ext {
-    imdgVersion = '3.13.1-SNAPSHOT'
+    imdgVersion = '3.12.1-SNAPSHOT'
 }
 
 repositories {

--- a/src/docs/asciidoc/jcache/overview.adoc
+++ b/src/docs/asciidoc/jcache/overview.adoc
@@ -17,22 +17,27 @@ the specification document (which is also the main documentation for functionali
 
 ==== Supported JCache Versions
 
-Two versions of the JCache specification have been released:
+Three versions of the JCache specification have been released:
 
-* The original release, version 1.0.0, was released in March 2014. Hazelcast versions 3.3.1 up to 3.9.2 (included) implement version 1.0.0 of the JCache specification. 
+* The original release, version 1.0.0, was released in March 2014. Hazelcast versions 3.3.1 up to 3.9.2 (included) implement version 1.0.0 of the JCache specification.
 * A maintenance release, version 1.1.0 was released in December 2017. Hazelcast version 3.9.3 and higher implement JCache specification version 1.1.0.
- 
-JCache 1.1.0 is backwards compatible with JCache 1.0.0. As a maintenance release, it introduces clarifications and bug fixes in the specification, reference implementation
-and TCK, without introducing any additional features. 
- 
+* A bug-fix patch release, version 1.1.1 was released in May 2019. Hazelcast version 3.12.1 and higher implement JCache 1.1.1.
+
+JCache 1.1.x versions are backwards compatible with JCache 1.0.0. As maintenance releases, JCache 1.1.x versions introduce clarifications and bug fixes in the specification, reference implementation
+and TCK, without introducing any additional features.
+
+==== Upgrading from JCache 1.1.0 to 1.1.1
+
+JCache 1.1.1 is a bug fix only release. There are no behavioral differences between JCache 1.1.0 and JCache 1.1.1 specification.
+
 ==== Upgrading from JCache 1.0.0 to 1.1.0
- 
+
 When upgrading from a Hazelcast version which implements JCache 1.0.0 to a version that implements version 1.1.0 of the specification, some behavioral differences must be taken into account:
 
 * Invoking `CacheManager.getCacheNames` on a closed `CacheManager` returns an empty iterator under JCache 1.0.0. While under JCache 1.1.0, it throws `IllegalStateException`.
 * Runtime type checking is removed from `CacheManager.getCache(String)`, so when using JCache 1.1.0 one may obtain a `Cache` by name even when its configured key/value types are not known.
 * Statistics effects of `Cache.putIfAbsent` on misses and hits are properly applied when using JCache 1.1.0, while under JCache 1.0.0 misses and hits were not updated.
- 
-Note that these behavioral differences apply on the Hazelcast member that executes the operation. Thus when performing a rolling member upgrade from a JCache 1.0.0-compliant Hazelcast version to a newer Hazelcast version that supports JCache 1.1.0, operations executed on the new members exhibit JCache 1.1.0 behavior while those executed on old members implement JCache 1.0.0 behavior.  
+
+Note that these behavioral differences apply on the Hazelcast member that executes the operation. Thus when performing a rolling member upgrade from a JCache 1.0.0-compliant Hazelcast version to a newer Hazelcast version that supports JCache 1.1.0, operations executed on the new members exhibit JCache 1.1.0 behavior while those executed on old members implement JCache 1.0.0 behavior.
 
 The complete list of issues addressed in JCache specification version 1.1.0 is https://github.com/jsr107/jsr107spec/milestone/2?closed=1[available on Github].

--- a/src/docs/asciidoc/jcache/setup.adoc
+++ b/src/docs/asciidoc/jcache/setup.adoc
@@ -23,7 +23,7 @@ For Maven users, the coordinates look like the following code:
 <dependency>
     <groupId>javax.cache</groupId>
     <artifactId>cache-api</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 </dependency>
 ----
 

--- a/src/docs/asciidoc/jcache/tck.adoc
+++ b/src/docs/asciidoc/jcache/tck.adoc
@@ -2,18 +2,18 @@
 === Testing for JCache Specification Compliance
 
 Hazelcast JCache is fully compliant with the JSR 107 TCK (Technology Compatibility Kit), and therefore is officially a JCache
-implementation. 
+implementation.
 
 You can test Hazelcast JCache for compliance by executing the TCK. Just perform the instructions below:
 
-* Checkout branch `v1.1.0` of the TCK from https://github.com/jsr107/jsr107tck[https://github.com/jsr107/jsr107tck].
-* Change the properties in https://github.com/jsr107/jsr107tck/blob/master/pom.xml[`pom.xml`] as shown below. Alternatively, you can set the values of these properties directly on the maven command line without editing any files as shown in the command line example below. 
+* Checkout tag `1.1.1` of the TCK from https://github.com/jsr107/jsr107tck/releases/tag/1.1.1[https://github.com/jsr107/jsr107tck].
+* Change the properties in https://github.com/jsr107/jsr107tck/blob/master/pom.xml[`pom.xml`] as shown below. Alternatively, you can set the values of these properties directly on the maven command line without editing any files as shown in the command line example below.
 * Run the TCK using the command `mvn clean install`. This runs the tests using an embedded Hazelcast member.
 
 [source,xml]
 ----
 <properties>
-    <jcache.version>1.1.0</jcache.version>
+    <jcache.version>1.1.1</jcache.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -54,8 +54,8 @@ $ git clone https://github.com/jsr107/jsr107tck
 
 $ cd jsr107tck
 
-$ git checkout v1.1.0
-(checkout v1.1.0 tag) 
+$ git checkout 1.1.1
+(checkout 1.1.1 tag)
 
 $ mvn -Dimplementation-groupId=com.hazelcast -Dimplementation-artifactId=hazelcast \
      -Dimplementation-version=3.10 \


### PR DESCRIPTION
Backport of #688 

To be merged as soon as https://github.com/hazelcast/hazelcast/pull/15009 & https://github.com/hazelcast/hazelcast-enterprise/pull/2958 are merged.