### PR TITLE
Omit unnecessary flags in curl and Content-type on empty responses

### DIFF
--- a/src/docs/asciidoc/hazelcast_clients.adoc
+++ b/src/docs/asciidoc/hazelcast_clients.adoc
@@ -2064,7 +2064,7 @@ An example `POST` call is shown below.
 
 [source,plain]
 ----
-$ curl -v -X POST -H "Content-Type: text/plain" -d "bar"
+$ curl -v -H "Content-Type: text/plain" -d "bar"
     http://10.20.17.1:5701/hazelcast/rest/maps/mapName/foo
 ----
 
@@ -2073,7 +2073,6 @@ It returns the following response if successful:
 [source,plain]
 ----
 < HTTP/1.1 200 OK
-< Content-Type: text/plain
 < Content-Length: 0
 ----
 
@@ -2121,7 +2120,6 @@ $ curl -v -X DELETE http://10.20.17.1:5701/hazelcast/rest/maps/mapName/foo
 
 ```
 < HTTP/1.1 200 OK
-< Content-Type: text/plain
 < Content-Length: 0
 ```
 
@@ -2135,7 +2133,6 @@ $ curl -v -X DELETE http://10.20.17.1:5701/hazelcast/rest/maps/mapName
 [source,plain]
 ----
 < HTTP/1.1 200 OK
-< Content-Type: text/plain
 < Content-Length: 0
 ----
 
@@ -2145,7 +2142,7 @@ You can use a `POST` call to create an item on the queue. An example is shown be
 
 [source,plain]
 ----
-$ curl -v -X POST -H "Content-Type: text/plain" -d "foo"
+$ curl -v -H "Content-Type: text/plain" -d "foo"
     http://10.20.17.1:5701/hazelcast/rest/queues/myEvents
 ----
 
@@ -2156,7 +2153,6 @@ It returns the following if successful:
 [source,plain]
 ----
 < HTTP/1.1 200 OK
-< Content-Type: text/plain
 < Content-Length: 0
 ----
 


### PR DESCRIPTION
When curl params "-X POST" and -d "" are sent altogether curl warns "Note: Unnecessary use of -X or --request, POST is already inferred.". Only -d "" is necessary in our examples.

Also, when response body is empty we do not send "Content-type" but examples show that we do. This is also fixed.
 
Fixes hazelcast/hazelcast#15491