### PR TITLE
Remove deprecated LocalReplicatedMapStats.getReplicationEventCount

### DIFF
--- a/src/docs/asciidoc/management.adoc
+++ b/src/docs/asciidoc/management.adoc
@@ -357,7 +357,6 @@ You can find the JMX API definition below with descriptions and the API methods 
 *  Max get latency ( `localMaxGetLatency` )
 *  Max remove latency ( `localMaxRemoveLatency` )
 *  Event count ( `localEventOperationCount` )
-*  Replication event count ( `localReplicationEventCount` )
 *  Other (keySet,entrySet etc..) operation count ( `localOtherOperationCount` )
 *  Total operation count ( `localTotal` )
 *  Clear ( `clear()` )


### PR DESCRIPTION
Always returns 0, looks like there is no replacement.

OS counterpart: https://github.com/hazelcast/hazelcast/pull/15676