### PR TITLE
Javadoc JAR for EE: added an example

### DIFF
--- a/src/docs/asciidoc/getting_started.adoc
+++ b/src/docs/asciidoc/getting_started.adoc
@@ -75,6 +75,12 @@ See the following example:
     <artifactId>hazelcast-enterprise-all</artifactId>
     <version>{imdg-version}</version>
 </dependency>
+<dependency>
+    <groupId>com.hazelcast</groupId>
+    <artifactId>hazelcast-enterprise-all</artifactId>
+    <version>{imdg-version}</version>
+    <classifier>javadoc</classifier>
+</dependency>
 ----
 
 [[setting-the-license-key]]


### PR DESCRIPTION
...as an extra Maven dependency in the 'Installing Hazelcast IMDG Enterprise' section.