### PR TITLE
Minor updates for latest state of 4.0

### DIFF
--- a/src/docs/asciidoc/hazelcast_clients.adoc
+++ b/src/docs/asciidoc/hazelcast_clients.adoc
@@ -986,8 +986,8 @@ Hazelcast Cloud is disabled for the Java client, by default (`enabled` attribute
 See this Hazelcast Cloud link:https://hazelcast.com/products/cloud/[web page^]
 for more information on Hazelcast Cloud.
 
-NOTE: Since this is a REST based discovery, you need to enable the REST listener service,
-too, by setting the `hazelcast.rest.enabled` property to `true`.
+NOTE: Since this is a REST based discovery, you need to enable the REST listener service.
+See the <<using-the-rest-endpoint-groups, Using the REST Endpoint Groups section>> on how to enable REST endpoints.
 
 [NOTE]
 ====
@@ -2112,7 +2112,6 @@ NOTE: REST client request listener service is not enabled by default.
 You should enable it on your cluster members to use REST client.
 It can be enabled using the `DATA` endpoint group; see the
 <<using-the-rest-endpoint-groups, Using the REST Endpoint Groups section>>.
-You can also use the `hazelcast.rest.enabled` group property to enable it.
 
 NOTE: All parameters that are used in REST API URLs, such as the distributed data structure and key names, must be
 link:https://en.wikipedia.org/wiki/Percent-encoding[URL encoded^] when composing a call. As an example, `name.with/special@chars`
@@ -2407,11 +2406,6 @@ the Memcache client request listener service using either one of the following c
     ...
 </hazelcast>
 ----
-
-NOTE: You can also use the `hazelcast.memcache.enabled`
-group property to enable the Memcache client request
-listener service, e.g., `java -Dhazelcast.memcache.enabled=true`.
-See <<configuring-with-system-properties>>.
 
 ==== Memcache Client Code Examples
 

--- a/src/docs/asciidoc/management.adoc
+++ b/src/docs/asciidoc/management.adoc
@@ -1802,10 +1802,6 @@ you must enable the Health Check using either one of the following configuration
 </hazelcast>
 ----
 
-NOTE: You can also use the `hazelcast.http.healthcheck.enabled`
-group property to enable the service, e.g., `java -Dhazelcast.http.healthcheck.enabled=true`.
-See <<configuring-with-system-properties>>.
-
 ==== Health Check
 
 This is Hazelcast's HTTP based health check implementation which provides
@@ -1833,8 +1829,9 @@ to learn more about each state of a Hazelcast cluster and member.
 ==== Using the healthcheck.sh Script
 
 The `healthcheck.sh` script comes with the Hazelcast package. Internally, it uses
-the HTTP-based Health Check endpoint and that is why you also need to set the
-`hazelcast.http.healthcheck.enabled` system property to `true`.
+the HTTP-based Health Check endpoint. You will need to enable the endpoint by using the
+`advanced-network` configuration element.
+See the <<health-check-and-monitoring, Health Check and Monitoring section>>.
 
 You can use the script to check health parameters in the following manner:
 
@@ -1910,8 +1907,7 @@ Assuming there is no member running under the address `127.0.0.1:5701`, the foll
 ```
 $ ./healthcheck.sh -a 127.0.0.1 -p 5701 -o cluster-safe
 Error while checking health of hazelcast cluster on ip 127.0.0.1 on port 5701.
-Please check that cluster is running and that health check is enabled (property set to true:
-'hazelcast.http.healthcheck.enabled' or 'hazelcast.rest.enabled').
+Please check that cluster is running and that health check is enabled in REST API configuration.
 ```
 
 ==== Health Monitor
@@ -1981,8 +1977,9 @@ to create a new monitor. Next, apply the following configuration according to yo
 ====== HTTP/HTTPS Monitors
 
 NOTE: Please note that you should enable the Hazelcast health check for
-HTTP/HTTPS monitors to run. To do this, set the `hazelcast.http.healthcheck.enabled` system property to true.
-By default, it is false.
+HTTP/HTTPS monitors to run. You will need to enable the endpoint by using the
+`advanced-network` configuration element.
+See the <<health-check-and-monitoring, Health Check and Monitoring section>>.
 
 **Using a GET request:**
 

--- a/src/docs/asciidoc/migration_guides.adoc
+++ b/src/docs/asciidoc/migration_guides.adoc
@@ -1888,17 +1888,20 @@ config.setEnabled(true);
 ----
 |===
 
-==== Undeprecation of Deprecated System Properties
+==== Removal of Deprecated System Properties
 
-The following properties have proven to be useful in containerized environments
-and no longer deprecated:
+The following deprecated cluster properties were removed:
 
 * `hazelcast.rest.enabled`
 * `hazelcast.memcache.enabled`
 * `hazelcast.http.healthcheck.enabled`
 
-See the <<system-properties, System Properties appendix>> for more information on
-these properties.
+Please see the <<using-the-rest-endpoint-groups, Using the REST Endpoint Groups section>> on how
+to configure Hazelcast instance to expose REST endpoints.
+Please see the the <<health-check-and-monitoring, Health Check and Monitoring section>> on how
+to enable the health check.
+Please see the <<memcache-client, Memcache Client section>> on how to enable memcache client
+request listener service.
 
 ==== Removal of Deprecations in `LoginModuleConfig`
 

--- a/src/docs/asciidoc/rolling_member_upgrades.adoc
+++ b/src/docs/asciidoc/rolling_member_upgrades.adoc
@@ -129,9 +129,6 @@ should be updated as follows:
 See the <<using-the-rest-endpoint-groups>> section for more
 information.
 
-Starting with Hazelcast IMDG 4.0, the `hazelcast.rest.enabled`
-group property can again be used.
-
 ====
 
 === Enabling Auto-Upgrading

--- a/src/docs/asciidoc/setting_up_clusters.adoc
+++ b/src/docs/asciidoc/setting_up_clusters.adoc
@@ -2176,10 +2176,10 @@ The following is the equivalent declarative configuration:
     </advanced-network>
     ...
     <wan-replication name="replicate-to-tokyo">
-        <wan-publisher group-name="clusterB">
-            <class-name>...</class-name>
-            <endpoint>tokyo</endpoint>
-        </wan-publisher>
+        <batch-publisher>
+            <cluster-name>clusterB</cluster-name>
+            <target-endpoints>...</target-endpoints>
+        </batch-publisher>
     </wan-replication>
     ...
     <map name="customer">

--- a/src/docs/asciidoc/system_properties.adoc
+++ b/src/docs/asciidoc/system_properties.adoc
@@ -281,14 +281,6 @@ See the <<public-address, Public Address section>>.
 | int
 | Maximum wait in seconds during graceful shutdown.
 
-|`hazelcast.http.healthcheck.enabled`
-|false
-|bool
-|Enable/disable Hazelcast's HTTP based health check implementation.
-When it is enabled, you can retrieve information about your cluster's health status (member state,
-cluster state, cluster size, etc.) by launching `+http://<your member's host IP>:5701/hazelcast/health+`.
-You can also use the `advanced-network` configuration element. See the <<health-check-and-monitoring, Health Check and Monitoring section>>.
-
 |`hazelcast.health.monitoring.delay.seconds`
 |30
 |int
@@ -587,13 +579,6 @@ name consisting of a randomly chosen adjective and the surname of a famous perso
 If set to `true`, a Moby name is generated. Otherwise, a name that is concatenation
 of a static prefix, number and cluster name is provided.
 
-|`hazelcast.memcache.enabled`
-| false
-| bool
-| Enables <<memcache-client, Memcache>> client request listener service.
-You can also use the `advanced-network` configuration element for the same purpose.
-See <<memcache-client>>.
-
 |`hazelcast.merge.first.run.delay.seconds`
 | 300
 | int
@@ -769,13 +754,6 @@ Set to `true` if you are using slow predicates or have > 100,000s entries per me
 This value defines the maximum number of returned elements for a single query result.
 If a query exceeds this number of elements, a QueryResultSizeExceededException is thrown.
 Its default value is -1, meaning it is disabled.
-
-|`hazelcast.rest.enabled`
-| false
-| bool
-| Enables <<rest-client, REST>> client request listener service.
-You can also use the `rest-api` configuration element for the same purpose.
-See the <<using-the-rest-endpoint-groups, Using the REST Endpoint Groups section>>.
 
 |`hazelcast.shutdownhook.enabled`
 | true


### PR DESCRIPTION
- `hazelcast.rest.enabled`, `hazelcast.memcache.enabled` and
`hazelcast.http.healthcheck.enabled` were in fact removed with
https://github.com/hazelcast/hazelcast/pull/15981
- fixed WAN replication configuration
- "group property" has been renamed to "cluster property"