### PR TITLE
Add validateIdentity option to TLS sections. Remove invalid note abou…

### DIFF
--- a/src/docs/asciidoc/security.adoc
+++ b/src/docs/asciidoc/security.adoc
@@ -282,12 +282,6 @@ types depend on your Operating system and the Java runtime.
 * `trustStore`: Path of your truststore file. The file truststore is a
 keystore file that contains a collection of certificates trusted by your
 application.
-+
-NOTE: If you configure TLS/SSL and do not specify the `trustStore` property,
-no default trusted certificates will be used; neither the keystore, nor the
-Java provided list of trusted CA certificates. Therefore, you ALWAYS need
-to configure the trustStore property.
-+
 * `trustStorePassword`: Password to unlock the truststore file.
 * `trustManagerAlgorithm`: Name of the algorithm based on which the
 trust managers are provided.
@@ -315,6 +309,7 @@ default value is `TLS`. Available values are:
 For the `protocol` property, we recommend you to provide TLS with its
 version information, e.g., `TLSv1.2`. Note that if you write only `TLS`,
 your application chooses the TLS version according to your Java version.
+* `validateIdentity`: Flag which allows enabling endpoint identity validation. It means, during the TLS handshke client verifies if the server's hostname (or IP address) matches the information in X.509 certificate (Subject Alternative Name extension). Possible values are `"true"` and `"false"` (default).
 
 ==== TLS/SSL for Hazelcast Clients
 
@@ -658,6 +653,7 @@ information, e.g., `TLSv1.2`. Note that if you
 provide only `SSL` or `TLS` as a value for the `protocol` property, they are
 converted to `SSLv3` and `TLSv1.2`, respectively. We strongly recommend to avoid
 SSL protocols.
+* `validateIdentity`: Flag which allows enabling endpoint identity validation. It means, during the TLS handshke client verifies if the server's hostname (or IP address) matches the information in X.509 certificate (Subject Alternative Name extension). Possible values are `"true"` and `"false"` (default).
 
 === Other TLS related configuration
 


### PR DESCRIPTION
This PR adds info about `validateIdentity` option in TLS factories. It also removes an invalid note about the default truststore.