### PR TITLE
Rename WanReplicationRef#setMergePolicy to setMergePolicyClassName in samples

### DIFF
--- a/src/main/java/wan/EnablingWRforCache.java
+++ b/src/main/java/wan/EnablingWRforCache.java
@@ -16,7 +16,7 @@ public class EnablingWRforCache {
 
         WanReplicationRef cacheWanRef = new WanReplicationRef();
         cacheWanRef.setName("my-wan-cluster");
-        cacheWanRef.setMergePolicy("com.hazelcast.spi.merge.PassThroughMergePolicy");
+        cacheWanRef.setMergePolicyClassName("com.hazelcast.spi.merge.PassThroughMergePolicy");
         cacheWanRef.setRepublishingEnabled(true);
         config.getCacheConfig("my-shared-cache").setWanReplicationRef(cacheWanRef);
 //end::wrcache[]

--- a/src/main/java/wan/EnablingWRforMap.java
+++ b/src/main/java/wan/EnablingWRforMap.java
@@ -17,7 +17,7 @@ public class EnablingWRforMap {
 
         WanReplicationRef wanRef = new WanReplicationRef();
         wanRef.setName("my-wan-cluster");
-        wanRef.setMergePolicy(PassThroughMergePolicy.class.getName());
+        wanRef.setMergePolicyClassName(PassThroughMergePolicy.class.getName());
         wanRef.setRepublishingEnabled(false);
         config.getMapConfig("my-shared-map").setWanReplicationRef(wanRef);
 //end::wrmap[]


### PR DESCRIPTION
* Counterpart of this core PR: https://github.com/hazelcast/hazelcast/pull/16403
* Fixes compilation of `WanReplicationRef` samples

cc @mmedenjak 