### PR TITLE
Update JMX docs for v4.0+

### DIFF
--- a/src/docs/asciidoc/management.adoc
+++ b/src/docs/asciidoc/management.adoc
@@ -421,20 +421,7 @@ You can find the JMX API definition below with descriptions and the API methods 
 *  **Node ( `HazelcastInstance.Node` )**
 *  Address ( `address` )
 *  Master address ( `masterAddress` )
-* **Event Service ( `HazelcastInstance.EventService` )**
-**  Event thread count  ( `eventThreadCount` )
-**  Event queue size ( `eventQueueSize` )
-**  Event queue capacity ( `eventQueueCapacity` )
-* **Operation Service ( `HazelcastInstance.OperationService` )**
-** Response queue size  ( `responseQueueSize` )
-**  Operation executor queue size ( `operationExecutorQueueSize` )
-** Running operation count ( `runningOperationsCount` )
-** Remote operation count ( `remoteOperationCount` )
-** Executed operation count ( `executedOperationCount` )
-** Operation thread count ( `operationThreadCount` )
-* **Proxy Service ( `HazelcastInstance.ProxyService` )**
-**  Proxy count ( `proxyCount` )
-* **Partition Service ( `HazelcastInstance.PartitionService` )**
+* **Partition Service ( `HazelcastInstance.PartitionServiceMBean` )**
 **  Partition count ( `partitionCount` )
 **  Active partition count ( `activePartitionCount` )
 ** Cluster Safe State ( `isClusterSafe` )
@@ -443,8 +430,6 @@ You can find the JMX API definition below with descriptions and the API methods 
 **  Client connection count ( `clientConnectionCount` )
 **  Active connection count ( `activeConnectionCount` )
 **  Connection count ( `connectionCount` )
-* **Client Engine ( `HazelcastInstance.ClientEngine` )**
-**  Client endpoint count ( `clientEndpointCount` )
 * **System Executor ( `HazelcastInstance.ManagedExecutorService` )**
 **  Name ( `name` )
 **  Work queue size ( `queueSize` )


### PR DESCRIPTION
- Removed beans based on https://github.com/hazelcast/hazelcast/pull/16425
- Fixed name of `HazelcastInstance.PartitionServiceMBean` https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/internal/jmx/PartitionServiceMBean.java