### PR TITLE
Added skipPdf flag for development purposes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,13 @@ asciidoctor {
       include 'index.adoc'
     }
 
-    backends = [ 'html5' /*, 'pdf' /*, 'multipage_html5', 'epub3'*/ ]
+    backends = [ 'html5' , 'pdf' /*, 'multipage_html5', 'epub3'*/ ]
+
+    if (project.hasProperty('skipPdf')) {
+	println "Skipping generation of PDF due to -PskipPdf flag set"
+        backends.remove('pdf')
+    }
+	
     attributes \
         'imdg-version': project.imdgVersion,
         'docBaseUrl': 'https://docs.hazelcast.org/docs/' + project.imdgVersion,


### PR DESCRIPTION
When developing refmanual, you could now use `./gradlew -PskipPdf build` to speed up the build. And before the release, we don't have to edit anything, so it's good for the automation.