### PR TITLE
Remove references to cluster password

### DIFF
--- a/src/docs/asciidoc/hazelcast_clients.adoc
+++ b/src/docs/asciidoc/hazelcast_clients.adoc
@@ -455,7 +455,7 @@ For programmatic configuration of the Hazelcast Java Client, just instantiate a 
 [source,java]
 ----
 ClientConfig clientConfig = new ClientConfig();
-clientConfig.setClusterName("dev").setClusterPassword("dev-pass");
+clientConfig.setClusterName("dev");
 clientConfig.setLoadBalancer(yourLoadBalancer);
 ----
 
@@ -1034,11 +1034,11 @@ See the <<near-cache, Near Cache section>> for a detailed explanation of the Nea
 [[client-cluster-configuration]]
 ===== Configuring Client Cluster
 
-Clients should provide a cluster name and password in order to connect to the cluster.
-You can configure them using `ClientConfig`, as shown below.
+Clients should provide a cluster name in order to connect to the cluster.
+You can configure it using `ClientConfig`, as shown below.
 
 ```
-clientConfig.setClusterName("dev").setClusterPassword("dev-pass");
+clientConfig.setClusterName("dev");
 ```
 
 [[client-security-configuration]]


### PR DESCRIPTION
These are possibly leftovers from the config changes that involved
group name and password. Client config does not have such an
element anymore.