### PR TITLE
JobTracker is no longer part of Hazelcast

### DIFF
--- a/src/docs/asciidoc/understanding_configuration.adoc
+++ b/src/docs/asciidoc/understanding_configuration.adoc
@@ -634,7 +634,6 @@ cluster members and adding the configuration should be retried by the user.
 
 Adding a new dynamic configuration is supported for all `add*Config` methods except the following:
 
-* `JobTracker`: It has been deprecated since Hazelcast 3.8.
 * `SplitBrainProtectionConfig`: A new split-brain protection configuration cannot be dynamically added but other
 configuration can reference split-brain protections configured in the existing static configuration.
 * `WanReplicationConfig`: A new WAN replication configuration cannot be dynamically


### PR DESCRIPTION
JobTracker was part of the Map/Reduced framework which was removed in Hazelcast 4