### PR TITLE
Move 'Document Revision History' to appendix

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -28,8 +28,6 @@ include::preface.adoc[]
 
 :numbered:
 
-include::revision_history.adoc[]
-
 include::getting_started.adoc[]
 
 include::hazelcast_overview.adoc[]
@@ -99,5 +97,7 @@ include::licenses.adoc[]
 include::phone_homes.adoc[]
 
 include::faq.adoc[]
+
+include::revision_history.adoc[]
 
 include::glossary.adoc[]

--- a/src/docs/asciidoc/revision_history.adoc
+++ b/src/docs/asciidoc/revision_history.adoc
@@ -1,4 +1,4 @@
-
+[appendix]
 
 [[document-revision-history]]
 == Document Revision History


### PR DESCRIPTION
The motivation for this change is to get user's attention to the content ASAP. I doubt that the average user is actually reading the content very often. I believe that people look at release notes and see what changed in the version, not directly in the content of the document.

I still believe that it's a very valuable page, but not that much that it would deserve to be in the very first pages. It makes more sense to me in the PDF file, but not on the website where the user is trying to find the information about IMDG ASAP.

BTW I love how easy it was to propose the change :)