### PR TITLE
Fix IMap packages.

### DIFF
--- a/src/docs/asciidoc/dds.adoc
+++ b/src/docs/asciidoc/dds.adoc
@@ -271,7 +271,7 @@ As you see, when a new member joins the cluster, it takes ownership and loads so
 data in the cluster. Eventually, it will carry almost "(1/n `*` total-data) + backups" of the data,
 reducing the load on other members.
 
-`HazelcastInstance.getMap()` returns an instance of `com.hazelcast.core.IMap` which extends
+`HazelcastInstance.getMap()` returns an instance of `com.hazelcast.map.IMap` which extends
 the `java.util.concurrent.ConcurrentMap` interface. Methods like
 `ConcurrentMap.putIfAbsent(key,value)` and `ConcurrentMap.replace(key,value)` can be used
 on the distributed map, as shown in the example below.

--- a/src/docs/asciidoc/distributed_query.adoc
+++ b/src/docs/asciidoc/distributed_query.adoc
@@ -1756,7 +1756,7 @@ divide the sum of the elements by their count (if non-zero).
 
 ==== Aggregations and Map Interfaces
 
-Aggregations are available on `com.hazelcast.core.IMap` only.
+Aggregations are available on `com.hazelcast.map.IMap` only.
 IMap offers the method `aggregate` to apply the aggregation logic on
 the map entries. This method can be called with or without a predicate. You can refer
 to its link:{docBaseUrl}/javadoc/com/hazelcast/map/IMap.html#aggregate-com.hazelcast.aggregation.Aggregator-[Javadoc^]
@@ -1836,7 +1836,7 @@ for the API's details.
 
 ===== Projections and Map Interfaces
 
-Projections are available on `com.hazelcast.core.IMap` only. IMap offers the method
+Projections are available on `com.hazelcast.map.IMap` only. IMap offers the method
 `project` to apply the projection logic on the map entries. This method can be called
 with or without a predicate. See its
 link:{docBaseUrl}/javadoc/com/hazelcast/map/IMap.html#project-com.hazelcast.projection.Projection-[Javadoc^]


### PR DESCRIPTION
Updates IMap packages from `core` to `map`

Also in `src/docs/asciidoc/getting_started.adoc#72` there is one more `core.IMap` in the code snippet but since I was not able to find the corresponding content in the doc I kept it unchanged - may be it's not supposed to be upgraded to 4.x at all.