### PR TITLE
Updates JCache provider information

### DIFF
--- a/src/docs/asciidoc/jcache/icache.adoc
+++ b/src/docs/asciidoc/jcache/icache.adoc
@@ -800,7 +800,7 @@ You can specify the full class name of custom `EvictionPolicyComparator`
 through `EvictionConfig`. This approach is useful when eviction configuration
 is specified on the client side
 and custom `EvictionPolicyComparator` implementation class itself does not
-exist at the client but at server side.
+exist at the client but at member side.
 
 [source,java]
 ----

--- a/src/docs/asciidoc/jcache/providers.adoc
+++ b/src/docs/asciidoc/jcache/providers.adoc
@@ -9,101 +9,66 @@ different JCache required features.
 Hazelcast has two types of providers. Depending on your
 application setup and the cluster topology,
 you can use the Client Provider (used by Hazelcast clients)
-or the Server Provider (used by cluster members).
+or the Member Provider (used by cluster members).
 
 For more information on cluster topologies and Hazelcast
 clients, see the <<hazelcast-topology, Hazelcast Topology section>>.
 
 ==== Configuring JCache Provider
 
-Configure the JCache `javax.cache.spi.CachingProvider`
-by either specifying the provider at the command line or
-by declaring the provider inside the Hazelcast configuration XML file.
-For more information on setting properties in this XML
-configuration file, see the <<jcache-declarative-configuration,
-JCache Declarative Configuration section>>.
+Hazelcast provides three `CachingProvider` implementations:
 
-Hazelcast implements a delegating `CachingProvider` that can
-automatically be configured for either client or member mode and that
-delegates to the real underlying implementation based on the
-user's choice. Hazelcast recommends that you use this `CachingProvider`
-implementation.
+ * A member-side implementation: the ``CacheManager``s created by this provider are backed by
+member-side ``HazelcastInstance``s.
+ * A client-side implementation: the ``CacheManager``s created by this provider are backed by
+client-side ``HazelcastInstance``s.
+ * A delegating caching provider that can be configured to delegate to the member-
+or client-side implementation.
 
-The delegating `CachingProvider`s fully qualified class name is
+When Hazelcast is the only JCache provider on the classpath, the default
+caching provider returned by `javax.cache.CachingProvider#getCachingProvider()` is
+the delegating `CachingProvider`.
 
-```
-com.hazelcast.cache.HazelcastCachingProvider
-```
-
-To configure the delegating provider at the command line,
-add the following parameter to the Java startup call,
-depending on the chosen provider:
-
-```
--Dhazelcast.jcache.provider.type=[client|server]
+```java
+// provides the default delegating caching provider
+CachingProvider provider = javax.cache.Caching.getCachingProvider();
 ```
 
-By default, the delegating `CachingProvider` is automatically
-picked up by the JCache SPI and provided as shown above.
-In cases where multiple `javax.cache.spi.CachingProvider`
-implementations reside on the classpath (like in some Application
-Server scenarios), you can select a `CachingProvider` by explicitly
-calling `Caching.getCachingProvider()`
-overloads and providing them using the canonical class name of
-the provider to be used. The class names of member and client providers
-provided by Hazelcast are mentioned in the following two subsections.
+By default, the delegating caching provider will choose the client-side implementation,
+however it can be configured to explicitly pick the client- or member-side implementation.
+This is achieved  by setting system property `hazelcast.jcache.provider.type` to value `client`
+or `member`. The legacy value `server` is also accepted as an alias for `member` however its
+usage is discouraged as it will be removed in a future version.
 
-NOTE: Hazelcast advises that you use the `Caching.getCachingProvider()` overloads to select a
-`CachingProvider` explicitly. This ensures that uploading to later
-environments or Application Server versions doesn't result in unexpected
-behavior like choosing a wrong `CachingProvider`.
-
-==== Configuring JCache with Client Provider
-
-For cluster topologies where Hazelcast light clients are used to
-connect to a remote Hazelcast cluster, use the Client Provider to
-configure JCache.
-
-The Client Provider provides the same features as the Server Provider.
-However, it does not hold data on its own but instead delegates requests
-and calls to the remotely connected cluster.
-
-The Client Provider can connect to multiple clusters at the same time.
-This can be achieved by scoping the client side
-`CacheManager` with different Hazelcast configuration files.
-For more information, see
-<<scoping-to-join-clusters, Scoping to Join Clusters>>.
-
-To request this `CachingProvider` using `Caching.getCachingProvider( String )` or
-`Caching.getCachingProvider( String, ClassLoader )`, use the
-following fully qualified class name:
-
-```
-com.hazelcast.client.cache.impl.HazelcastClientCachingProvider
+```java
+System.setProperty("hazelcast.jcache.provider.type", "member");
+// the returned provider will delegate to the member-side caching provider
+CachingProvider provider = javax.cache.Caching.getCachingProvider();
 ```
 
-==== Configuring JCache with Server Provider
+The default `CachingProvider` can be also configured by setting its fully qualified
+class name as the value of system property `javax.cache.spi.CachingProvider`.
+The system property can be defined at the `java` command line (using
+`-Djavax.cache.spi.CachingProvider=<fully-qualified-class-name>`) or
+programmatically using `java.lang.System#setProperty(String, String)`.
 
-If a Hazelcast member is embedded into an application directly
-and the Hazelcast client is not used, the Server Provider is
-required. In this case, the member itself becomes a part of
-the distributed cache and requests and operations are distributed
-directly across the cluster by its given key.
+The JCache API also provides methods to explicitly request instantiation of
+a specific `CachingProvider` by supplying its fully qualified class name. This is
+useful to explicitly choose Hazelcast as `CachingProvider` in case multiple
+implementations reside on the classpath.
 
-The Server Provider provides the same features as the Client
-provider, but it keeps data in the local Hazelcast member and also distributes
-non-owned keys to other direct cluster members.
-
-Like the Client Provider, the Server Provider can connect to
-multiple clusters at the same time. This can be achieved by
-scoping the client side `CacheManager` with different Hazelcast
-configuration files. For more
-information, see <<scoping-to-join-clusters, Scoping to Join Clusters>>.
-
-To request this `CachingProvider` using `Caching.getCachingProvider( String )` or
-`Caching.getCachingProvider( String, ClassLoader )`, use the
-following fully qualified class name:
-
+```java
+// provides the member-side caching provider
+CachingProvider provider = Caching.getCachingProvider("com.hazelcast.cache.HazelcastMemberCachingProvider");
 ```
-com.hazelcast.cache.impl.HazelcastServerCachingProvider
-```
+
+Since Hazelcast 4.0.3 the fully qualified class names for Hazelcast's `CachingProvider` implementations are:
+
+ * Delegating `CachingProvider` (picks member- or client-side provider depending on configuration):
+`com.hazelcast.cache.HazelcastCachingProvider`
+ * Member-side: `com.hazelcast.cache.HazelcastMemberCachingProvider`. The legacy class name
+`com.hazelcast.cache.impl.HazelcastServerCachingProvider` is also accepted, however its usage is
+discouraged and will be removed in a future version.
+ * Client-side: `com.hazelcast.client.cache.HazelcastClientCachingProvider`. The legacy class name
+`com.hazelcast.client.cache.impl.HazelcastClientCachingProvider` is also accepted, however its usage is
+discouraged and will be removed in a future version.

--- a/src/docs/asciidoc/migration_guides.adoc
+++ b/src/docs/asciidoc/migration_guides.adoc
@@ -29,6 +29,13 @@ in the `hazelcast-client` module have been moved to `hazelcast`.
 * Also the `com.hazelcast.client` Java module is not used anymore. All classes
 are now available within the `com.hazelcast.core` module.
 
+==== JCache default Caching Provider
+
+The default `CachingProvider` is the client-side `CachingProvider`. In order to select the
+member-side `CachingProvider`, users can specify the member-side `CachingProvider` by defining
+Hazelcast property `hazelcast.jcache.provider.type`. See the <<configuring-jcache-provider,
+Configuring JCache Provider>> section for more details.
+
 ==== Removal of User Defined Services
 
 Hazelcast IMDG's public SPI (Service Provider Interface) which was known as


### PR DESCRIPTION
Since https://github.com/hazelcast/hazelcast/pull/17320 was merged, new public class names should be advertised for JCache provider configuration. Also aligns to "member" terminology instead of "server" and removes some redundant info from the JCache providers section.

Fixes #854 on `master` branch. 