### PR TITLE
Clarify the paging predicate chapter

### DIFF
--- a/src/docs/asciidoc/distributed_query.adoc
+++ b/src/docs/asciidoc/distributed_query.adoc
@@ -413,8 +413,8 @@ predicate has a filter
 to retrieve the objects with an "age" greater than or equal to 18.
 * Then a `PagingPredicate` is constructed in which the page size is 5,
 so that there are five objects in each page.
-The first time the values are called creates the first page.
-* It gets subsequent pages with the `nextPage()`
+The first time the `values()` method is called, the first page is fetched.
+* Finally, the subsequent page is fetched by calling the `nextPage()`
 method of `PagingPredicate` and querying the map again with the
 updated `PagingPredicate`.
 
@@ -434,8 +434,8 @@ values = map.values( pagingPredicate );
 ----
 
 If a comparator is not specified for `PagingPredicate`, but you want
-to get a collection of keys or values page by page, this collection must
-be an instance of `Comparable` (i.e., it must implement `java.lang.Comparable`).
+to get a collection of keys or values page by page, keys or values must
+be instances of `Comparable` (i.e., they must implement `java.lang.Comparable`).
 Otherwise, the `java.lang.IllegalArgument` exception is thrown.
 
 You can also access a specific page more
@@ -445,7 +445,7 @@ once instead of reaching the hundredth page one by one using the `nextPage()` me
 Note that this feature tires the memory and see the
 link:{docBaseUrl}/javadoc/com/hazelcast/query/PagingPredicate.html[PagingPredicate Javadoc^].
 
-Paging Predicate, also known as Order & Limit, is not supported in
+NOTE: Paging Predicate, also known as Order & Limit, is not supported in
 Transactional Context.
 
 ==== Filtering with Partition Predicate


### PR DESCRIPTION
There were some problems with that chapter. Namely,

- Explanation of the code sample was not clear. For example, ``values``
should refer to the method call, but it was used in plural form, probably
referring to the returned collection.
-  If the comparator is not set, keys or values of the collection should
be comparable, not the collection itself.
- The note about the transactional context is not related to the paragraphs
above. It makes sense to convert it into a note.

Credit goes to Andrey for spotting these problems on https://github.com/hazelcast/hazelcast-python-client/pull/232