### PR TITLE
Update rolling upgrade versions

### DIFF
--- a/src/docs/asciidoc/installing_upgrading.adoc
+++ b/src/docs/asciidoc/installing_upgrading.adoc
@@ -385,7 +385,7 @@ This chapter explains the procedure of upgrading the version of Hazelcast member
 ==== Terminology
 
 * **Minor version**: A version change after the decimal point, e.g.,
-3.12 and 3.13.
+3.11 and 3.12.
 * **Patch version**: A version change after the second decimal point,
 e.g., 3.12.1 and 3.12.2.
 * **Member codebase version**: The `major.minor.patch` version of the
@@ -423,30 +423,36 @@ patch or minor versions for prolonged periods of time.
 
 NOTE: The version numbers used in this chapter are examples.
 
-Let's assume a cluster with four members running on codebase version `3.12.0` with cluster version `3.12`, that should be upgraded to codebase version
-`3.13.0` and cluster version `3.13`. The rolling upgrade process for this cluster, i.e., replacing existing `3.12.0` members one by one with an upgraded
-one at version `3.13.0`, includes the following steps which should be repeated for each member:
+Let's assume a cluster with four members running on codebase version `4.0.0` with cluster version `4.0`, that should be
+upgraded to codebase version
+`4.1.0` and cluster version `4.1`. The rolling upgrade process for this cluster, i.e., replacing existing `4.0.0` members one
+by one with an upgraded
+one at version `4.1.0`, includes the following steps which should be repeated for each member:
 
-* Gracefully shut down an existing `3.12.0` member.
+* Gracefully shut down an existing `4.0.0` member.
 * Wait until all partition migrations are completed; during migrations,
 membership changes (member joins or removals) are not allowed.
-* Update the member with the new `3.13.0` Hazelcast binaries.
+* Update the member with the new `4.1.0` Hazelcast binaries.
 * Start the member and wait until it joins the cluster. You should
 see something like the following in your logs:
 +
 ```
  ...
- INFO: [192.168.2.2]:5701 [cluster] [3.13] Hazelcast 3.9 (20170630 - a67dc3a) starting at [192.168.2.2]:5701
+ INFO: [192.168.2.2]:5701 [cluster] [4.1] Hazelcast Enterprise 4.1 (20201103 - 2a1a477, eded1cf) starting at [192.168.2.2]:5701
  ...
- INFO: [192.168.2.2]:5701 [cluster] [3.13] Cluster version set to 3.12
+ INFO: [192.168.2.2]:5701 [cluster] [4.1] Cluster version set to 4.0
 ```
 
-The version in brackets (`[3.13]`) still denotes the member's codebase version (running on the hypothetical `hazelcast-3.13.jar` binary). Once the member locates the existing cluster members, it sends its join request to the master. The master validates that the new member is allowed to join the cluster and lets the new member know that the cluster is currently operating at `3.12` cluster version. The new member sets `3.12` as its cluster version and starts operating normally.
+The version in brackets (`[4.1]`) still denotes the member's codebase version (running on the hypothetical
+`hazelcast-enterprise-4.1.jar` binary). Once the member locates the existing cluster members, it sends its join request to the master. The master
+validates that the new member is allowed to join the cluster and lets the new member know that the cluster is currently
+operating at `4.0` cluster version. The new member sets `4.0` as its cluster version and starts operating normally.
 
-At this point all members of the cluster have been upgraded to codebase version `3.13.0` but the cluster still operates at cluster version `3.12`. In order to use `3.13` features the cluster version must be changed to `3.13`.
+At this point all members of the cluster have been upgraded to codebase version `4.1.0` but the cluster still operates at
+cluster version `4.0`. In order to use `4.1` features the cluster version must be changed to `4.1`.
 
-NOTE: Rolling upgrade can be used for one version at a time, e.g., 3.n to 3.n+1. You cannot upgrade
-your members, for example, from 3.13 to 3.15 in a single rolling upgrade session.
+NOTE: Rolling upgrade can be used for one version at a time, e.g., 4.n to 4.n+1. You cannot upgrade
+your members, for example, from 4.0 to 4.2 in a single rolling upgrade session.
 
 [[upgrading-cluster-version]]
 ==== Upgrading Cluster Version


### PR DESCRIPTION
Use 4.0 and 4.1 versions instead of 3.12 and (the non-existent) 3.13.
Also, added enterprise to the jar names as rolling upgrade is an
enterprise feature.