### PR TITLE
Fix a bug in 'configuration override section'

### DIFF
--- a/src/docs/asciidoc/understanding_configuration.adoc
+++ b/src/docs/asciidoc/understanding_configuration.adoc
@@ -664,7 +664,7 @@ NOTE: All entries need to mirror YAML configuration structure which differs slig
 In order to make Hazelcast recognize environment variables
 as valid configuration entries, they need to obey the following rules:
 
-* Each configuration entry needs to start with `HZ_` or `HZ_CLIENT_`.
+* Each configuration entry needs to start with `HZ_` or `HZCLIENT_`.
 * A new configuration level should be introduced with an underscore (`_`).
 * Dashes (`-`) should be removed.
 * Variable names should be in upper case.


### PR DESCRIPTION
Client-specific entries need to start with `HZCLIENT` and not `HZ_CLIENT`