### PR TITLE
Update venues for Hazelcast cloud

### DIFF
--- a/src/docs/asciidoc/installing_upgrading.adoc
+++ b/src/docs/asciidoc/installing_upgrading.adoc
@@ -192,11 +192,9 @@ clusters for you. You can use Hazelcast Cloud as a low-latency high-performance
 caching or data layer for your microservices, and it is also a nice solution
 for state management of serverless functions (AWS Lambda).
 
-Hazelcast Cloud uses Docker and Kubernetes, and is powered by Hazelcast IMDG
-Enterprise HD. It is initially available on Amazon Web Services (AWS), to be
-followed by Microsoft Azure and Google Cloud Platform (GCP). Since it is based
-on Hazelcast IMDG Enterprise HD, it features advanced functionality such as
-TLS, multi-region, persistence, and high availability.
+Hazelcast Cloud supports deployment of clusters on Amazon Web Services (AWS), Microsoft Azure and as of early December
+2020, Google Cloud Platform (GCP). Since it is based on Hazelcast IMDG Enterprise it features advanced functionality
+such as TLS, multi-region, multi-cloud & hybrid cloud cluster replication, persistence, and high availability.
 
 [[deploying-in-kubernetes]]
 === Kubernetes/OpenShift Deployment


### PR DESCRIPTION
Some minor changes, we now have Azure and soon GCP.  Old file was out of date since early this year saying Azure wasn't available.

Also product names were wrong.  It is not "Hazelcast Enterprise.  There is no "Hazelcast Enterprise HD".